### PR TITLE
Add header to gff3 output

### DIFF
--- a/helixer_post_bin/src/analysis.rs
+++ b/helixer_post_bin/src/analysis.rs
@@ -1,12 +1,12 @@
-use crate::results::{Species, Sequence};
-use crate::results::conv::{ClassPrediction, PhasePrediction, ArrayConvInto};
-use std::io::Write;
-use crate::analysis::rater::{SequenceRating, SequenceRater};
-use crate::gff::GffWriter;
-use crate::analysis::window::BasePredictionWindowThresholdIterator;
-use crate::analysis::hmm::{PredictionHmm, HmmStateRegion};
-use crate::analysis::gff_conv::hmm_solution_to_gff;
 use crate::analysis::extractor::{BasePredictionExtractor, ComparisonExtractor};
+use crate::analysis::gff_conv::hmm_solution_to_gff;
+use crate::analysis::hmm::{HmmStateRegion, PredictionHmm};
+use crate::analysis::rater::{SequenceRater, SequenceRating};
+use crate::analysis::window::BasePredictionWindowThresholdIterator;
+use crate::gff::GffWriter;
+use crate::results::conv::{ArrayConvInto, ClassPrediction, PhasePrediction};
+use crate::results::{Sequence, Species};
+use std::io::Write;
 
 pub mod extractor;
 pub mod gff_conv;
@@ -14,9 +14,7 @@ pub mod hmm;
 pub mod rater;
 pub mod window;
 
-
-pub struct Analyzer<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
-{
+pub struct Analyzer<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> {
     bp_extractor: BasePredictionExtractor<'a, TC, TP>,
     comp_extractor: ComparisonExtractor<'a>,
     window_size: usize,
@@ -25,24 +23,45 @@ pub struct Analyzer<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<Ph
     min_coding_length: usize,
 }
 
-impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> Analyzer<'a, TC, TP>
+impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
+    Analyzer<'a, TC, TP>
 {
-    pub fn new(bp_extractor: BasePredictionExtractor<'a, TC, TP>, comp_extractor: ComparisonExtractor<'a>,
-               window_size: usize, edge_threshold: f32, peak_threshold: f32, min_coding_length: usize) -> Analyzer<'a, TC, TP>
-    {
-        Analyzer { bp_extractor, comp_extractor, window_size, edge_threshold, peak_threshold, min_coding_length }
+    pub fn new(
+        bp_extractor: BasePredictionExtractor<'a, TC, TP>,
+        comp_extractor: ComparisonExtractor<'a>,
+        window_size: usize,
+        edge_threshold: f32,
+        peak_threshold: f32,
+        min_coding_length: usize,
+    ) -> Analyzer<'a, TC, TP> {
+        Analyzer {
+            bp_extractor,
+            comp_extractor,
+            window_size,
+            edge_threshold,
+            peak_threshold,
+            min_coding_length,
+        }
     }
 
-    pub fn has_ref(&self) -> bool { self.comp_extractor.has_ref() }
+    pub fn has_ref(&self) -> bool {
+        self.comp_extractor.has_ref()
+    }
 
-    fn process_sequence_1d<W:Write>(&self, species: &Species, seq: &Sequence, rev: bool, bp_iter: BasePredictionWindowThresholdIterator<TC, TP>,
-                                    gene_idx: &mut usize, rater: &mut SequenceRater, gff_writer: &mut GffWriter<W>) -> (usize, usize)
-    {
+    fn process_sequence_1d<W: Write>(
+        &self,
+        species: &Species,
+        seq: &Sequence,
+        rev: bool,
+        bp_iter: BasePredictionWindowThresholdIterator<TC, TP>,
+        gene_idx: &mut usize,
+        rater: &mut SequenceRater,
+        gff_writer: &mut GffWriter<W>,
+    ) -> (usize, usize) {
         let mut window_count = 0;
         let mut window_length_total = 0;
 
-        for (bp_vec, _total_vec, start_pos, _peak) in bp_iter
-        {
+        for (bp_vec, _total_vec, start_pos, _peak) in bp_iter {
             window_count += 1;
             window_length_total += bp_vec.len();
 
@@ -51,55 +70,129 @@ impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
             let hmm = PredictionHmm::new(bp_vec);
             let maybe_solution = hmm.solve();
 
-            if let Some(solution) = maybe_solution
-            {
+            if let Some(solution) = maybe_solution {
                 //solution.dump(start_pos);
                 let solution_regions = solution.trace_regions();
                 let genes = HmmStateRegion::split_genes(solution_regions);
 
-                for (gene_regions, coding_length) in genes.iter()
-                { rater.rate_regions(start_pos, &gene_regions, *coding_length < self.min_coding_length); }
+                for (gene_regions, coding_length) in genes.iter() {
+                    rater.rate_regions(
+                        start_pos,
+                        &gene_regions,
+                        *coding_length < self.min_coding_length,
+                    );
+                }
 
-                let gff_records = hmm_solution_to_gff(genes, species.get_name(), seq.get_name(), "Helixer",
-                                                      rev, start_pos, seq.get_length(), self.min_coding_length, gene_idx);
-                gff_writer.write_records(&gff_records).expect("Failed to write to GFF");
-            } else { panic!("No solution at {} {} - {}", seq.get_name(), start_pos, end_pos); }
+                let gff_records = hmm_solution_to_gff(
+                    genes,
+                    species.get_name(),
+                    seq.get_name(),
+                    "Helixer",
+                    rev,
+                    start_pos,
+                    seq.get_length(),
+                    self.min_coding_length,
+                    gene_idx,
+                );
+                gff_writer
+                    .write_records(&gff_records)
+                    .expect("Failed to write to GFF");
+            } else {
+                panic!(
+                    "No solution at {} {} - {}",
+                    seq.get_name(),
+                    start_pos,
+                    end_pos
+                );
+            }
         }
 
         (window_count, window_length_total)
     }
 
-    pub fn process_sequence<W: Write>(&self, species: &Species, seq: &Sequence,
-                                      fwd_rating: &mut SequenceRating, rev_rating: &mut SequenceRating, gff_writer: &mut GffWriter<W>) -> (usize, usize)
-    {
+    pub fn process_sequence<W: Write>(
+        &self,
+        species: &Species,
+        seq: &Sequence,
+        fwd_rating: &mut SequenceRating,
+        rev_rating: &mut SequenceRating,
+        gff_writer: &mut GffWriter<W>,
+    ) -> (usize, usize) {
         let id = seq.get_id();
-        println!("  BP_Extractor for Sequence {} - ID {}", seq.get_name(), id.inner());
+        println!(
+            "  BP_Extractor for Sequence {} - ID {}",
+            seq.get_name(),
+            id.inner()
+        );
 
         let mut gene_idx = 1;
 
-        let fwd_bp_iter =
-            BasePredictionWindowThresholdIterator::new(self.bp_extractor.fwd_iterator(id), self.window_size, self.edge_threshold, self.peak_threshold).unwrap();
+        let fwd_bp_iter = BasePredictionWindowThresholdIterator::new(
+            self.bp_extractor.fwd_iterator(id),
+            self.window_size,
+            self.edge_threshold,
+            self.peak_threshold,
+        )
+        .unwrap();
 
-        let mut fwd_comp_rater = SequenceRater::new(self.comp_extractor.fwd_iterator(id), seq.get_length() as usize);
+        let mut fwd_comp_rater = SequenceRater::new(
+            self.comp_extractor.fwd_iterator(id),
+            seq.get_length() as usize,
+        );
 
-        let (fwd_window_count, fwd_window_length_total) = self.process_sequence_1d(species, seq, false, fwd_bp_iter, &mut gene_idx, &mut fwd_comp_rater, gff_writer);
+        let (fwd_window_count, fwd_window_length_total) = self.process_sequence_1d(
+            species,
+            seq,
+            false,
+            fwd_bp_iter,
+            &mut gene_idx,
+            &mut fwd_comp_rater,
+            gff_writer,
+        );
         let fwd_seq_rating = fwd_comp_rater.calculate_stats();
-        println!("Forward for Sequence {} - ID {}", seq.get_name(), id.inner());
+        println!(
+            "Forward for Sequence {} - ID {}",
+            seq.get_name(),
+            id.inner()
+        );
         fwd_seq_rating.dump(self.comp_extractor.has_ref());
 
         fwd_rating.accumulate(&fwd_seq_rating);
 
-        let rev_bp_iter =
-            BasePredictionWindowThresholdIterator::new(self.bp_extractor.rev_iterator(id), self.window_size, self.edge_threshold, self.peak_threshold).unwrap();
-        let mut rev_comp_rater = SequenceRater::new(self.comp_extractor.rev_iterator(id), seq.get_length() as usize);
+        let rev_bp_iter = BasePredictionWindowThresholdIterator::new(
+            self.bp_extractor.rev_iterator(id),
+            self.window_size,
+            self.edge_threshold,
+            self.peak_threshold,
+        )
+        .unwrap();
+        let mut rev_comp_rater = SequenceRater::new(
+            self.comp_extractor.rev_iterator(id),
+            seq.get_length() as usize,
+        );
 
-        let (rev_window_count, rev_window_length_total) = self.process_sequence_1d(species, seq, true, rev_bp_iter, &mut gene_idx, &mut rev_comp_rater, gff_writer);
+        let (rev_window_count, rev_window_length_total) = self.process_sequence_1d(
+            species,
+            seq,
+            true,
+            rev_bp_iter,
+            &mut gene_idx,
+            &mut rev_comp_rater,
+            gff_writer,
+        );
         let rev_seq_rating = rev_comp_rater.calculate_stats();
-        println!("Reverse for Sequence {} - ID {}", seq.get_name(), id.inner());
+        println!(
+            "Reverse for Sequence {} - ID {}",
+            seq.get_name(),
+            id.inner()
+        );
         rev_seq_rating.dump(self.comp_extractor.has_ref());
 
         rev_rating.accumulate(&rev_seq_rating);
 
-        (fwd_window_count+rev_window_count, fwd_window_length_total+rev_window_length_total)
-      }
+        (
+            fwd_window_count + rev_window_count,
+            fwd_window_length_total + rev_window_length_total,
+        )
+    }
 }

--- a/helixer_post_bin/src/analysis/extractor.rs
+++ b/helixer_post_bin/src/analysis/extractor.rs
@@ -1,11 +1,15 @@
-
-use crate::results::{SequenceID, SpeciesID, HelixerResults, Result};
-use crate::results::conv::{ArrayConvInto, ClassPrediction, PhasePrediction, Bases, ClassReference, PhaseReference};
+use crate::results::conv::{
+    ArrayConvInto, Bases, ClassPrediction, ClassReference, PhasePrediction, PhaseReference,
+};
 use crate::results::iter::{BlockedDataset2D, BlockedDataset2DIter};
+use crate::results::{HelixerResults, Result, SequenceID, SpeciesID};
 
 // Hard coded as Bases / Predictions for now. Would make more sense to have all base-level datasets optionally available (and seekable)
-pub struct BasePredictionExtractor<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
-{
+pub struct BasePredictionExtractor<
+    'a,
+    TC: ArrayConvInto<ClassPrediction>,
+    TP: ArrayConvInto<PhasePrediction>,
+> {
     helixer_res: &'a HelixerResults,
 
     bases_blocked_dataset: BlockedDataset2D<'a, f32, Bases>,
@@ -14,64 +18,99 @@ pub struct BasePredictionExtractor<'a, TC: ArrayConvInto<ClassPrediction>, TP: A
     phase_pred_blocked_dataset: BlockedDataset2D<'a, TP, PhasePrediction>,
 }
 
-impl<'a> BasePredictionExtractor<'a, f32, f32>
-{
-    pub fn new_from_prediction(helixer_res: &'a HelixerResults) -> Result<BasePredictionExtractor<'a, f32, f32>>
-    {
+impl<'a> BasePredictionExtractor<'a, f32, f32> {
+    pub fn new_from_prediction(
+        helixer_res: &'a HelixerResults,
+    ) -> Result<BasePredictionExtractor<'a, f32, f32>> {
         let bases_blocked_dataset = helixer_res.get_x()?;
         let class_pred_blocked_dataset = helixer_res.get_class_predictions()?;
         let phase_pred_blocked_dataset = helixer_res.get_phase_predictions()?;
 
-        Ok(BasePredictionExtractor { helixer_res, bases_blocked_dataset, class_pred_blocked_dataset, phase_pred_blocked_dataset })
+        Ok(BasePredictionExtractor {
+            helixer_res,
+            bases_blocked_dataset,
+            class_pred_blocked_dataset,
+            phase_pred_blocked_dataset,
+        })
     }
 }
 
-impl<'a> BasePredictionExtractor<'a, i8, i8>
-{
-    pub fn new_from_pseudo_predictions(helixer_res: &'a HelixerResults) -> Result<Option<BasePredictionExtractor<'a, i8, i8>>>
-    {
+impl<'a> BasePredictionExtractor<'a, i8, i8> {
+    pub fn new_from_pseudo_predictions(
+        helixer_res: &'a HelixerResults,
+    ) -> Result<Option<BasePredictionExtractor<'a, i8, i8>>> {
         let bases_blocked_dataset = helixer_res.get_x()?;
 
-        match (helixer_res.get_class_reference_as_pseudo_predictions()?, helixer_res.get_phase_reference_as_pseudo_predictions()?)
-            {
-            (Some(class_pred_blocked_dataset), Some(phase_pred_blocked_dataset)) =>
-                    Ok(Some(BasePredictionExtractor { helixer_res, bases_blocked_dataset, class_pred_blocked_dataset, phase_pred_blocked_dataset })),
-            (Some(_), None) => { eprintln!("Warning: Ref Class predictions without Ref Phase predictions"); Ok(None) },
-            (None, Some(_)) => { eprintln!("Warning: Ref Phase predictions without Ref Class predictions"); Ok(None) },
-            (None, None) => Ok(None),
+        match (
+            helixer_res.get_class_reference_as_pseudo_predictions()?,
+            helixer_res.get_phase_reference_as_pseudo_predictions()?,
+        ) {
+            (Some(class_pred_blocked_dataset), Some(phase_pred_blocked_dataset)) => {
+                Ok(Some(BasePredictionExtractor {
+                    helixer_res,
+                    bases_blocked_dataset,
+                    class_pred_blocked_dataset,
+                    phase_pred_blocked_dataset,
+                }))
             }
+            (Some(_), None) => {
+                eprintln!("Warning: Ref Class predictions without Ref Phase predictions");
+                Ok(None)
+            }
+            (None, Some(_)) => {
+                eprintln!("Warning: Ref Phase predictions without Ref Class predictions");
+                Ok(None)
+            }
+            (None, None) => Ok(None),
+        }
     }
 }
 
-
-impl<'a,  TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> BasePredictionExtractor<'a, TC, TP>
+impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
+    BasePredictionExtractor<'a, TC, TP>
 {
-    pub fn fwd_iterator(&'a self, sequence_id: SequenceID) -> BasePredictionIterator<'a, TC, TP>
-    {
+    pub fn fwd_iterator(&'a self, sequence_id: SequenceID) -> BasePredictionIterator<'a, TC, TP> {
         let sequence = self.helixer_res.get_index().get_sequence_by_id(sequence_id);
 
         let base_iter = self.bases_blocked_dataset.fwd_iter(sequence_id);
         let class_pred_iter = self.class_pred_blocked_dataset.fwd_iter(sequence_id);
         let phase_pred_iter = self.phase_pred_blocked_dataset.fwd_iter(sequence_id);
 
-        BasePredictionIterator::new(self, sequence.get_species_id(), sequence_id, false, base_iter, class_pred_iter, phase_pred_iter)
+        BasePredictionIterator::new(
+            self,
+            sequence.get_species_id(),
+            sequence_id,
+            false,
+            base_iter,
+            class_pred_iter,
+            phase_pred_iter,
+        )
     }
 
-    pub fn rev_iterator(&'a self, sequence_id: SequenceID) -> BasePredictionIterator<'a, TC, TP>
-    {
+    pub fn rev_iterator(&'a self, sequence_id: SequenceID) -> BasePredictionIterator<'a, TC, TP> {
         let sequence = self.helixer_res.get_index().get_sequence_by_id(sequence_id);
 
         let base_iter = self.bases_blocked_dataset.rev_iter(sequence_id);
         let class_pred_iter = self.class_pred_blocked_dataset.rev_iter(sequence_id);
         let phase_pred_iter = self.phase_pred_blocked_dataset.rev_iter(sequence_id);
 
-        BasePredictionIterator::new(self, sequence.get_species_id(), sequence_id, true, base_iter, class_pred_iter, phase_pred_iter)
+        BasePredictionIterator::new(
+            self,
+            sequence.get_species_id(),
+            sequence_id,
+            true,
+            base_iter,
+            class_pred_iter,
+            phase_pred_iter,
+        )
     }
 }
 
-
-pub struct BasePredictionIterator<'a,  TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
-{
+pub struct BasePredictionIterator<
+    'a,
+    TC: ArrayConvInto<ClassPrediction>,
+    TP: ArrayConvInto<PhasePrediction>,
+> {
     extractor: &'a BasePredictionExtractor<'a, TC, TP>,
 
     species_id: SpeciesID,
@@ -84,54 +123,74 @@ pub struct BasePredictionIterator<'a,  TC: ArrayConvInto<ClassPrediction>, TP: A
     phase_pred_iter: BlockedDataset2DIter<'a, TP, PhasePrediction>,
 }
 
-impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> BasePredictionIterator<'a, TC, TP>
+impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
+    BasePredictionIterator<'a, TC, TP>
 {
-    fn new(extractor: &'a BasePredictionExtractor<'a, TC, TP>, species_id: SpeciesID, sequence_id: SequenceID, rc: bool, base_iter: BlockedDataset2DIter<'a, f32, Bases>,
-           class_pred_iter: BlockedDataset2DIter<'a, TC, ClassPrediction>, phase_pred_iter: BlockedDataset2DIter<'a, TP, PhasePrediction>) -> BasePredictionIterator<'a, TC, TP>
-    {
-        BasePredictionIterator { extractor, species_id, sequence_id, rc, base_iter, class_pred_iter, phase_pred_iter }
+    fn new(
+        extractor: &'a BasePredictionExtractor<'a, TC, TP>,
+        species_id: SpeciesID,
+        sequence_id: SequenceID,
+        rc: bool,
+        base_iter: BlockedDataset2DIter<'a, f32, Bases>,
+        class_pred_iter: BlockedDataset2DIter<'a, TC, ClassPrediction>,
+        phase_pred_iter: BlockedDataset2DIter<'a, TP, PhasePrediction>,
+    ) -> BasePredictionIterator<'a, TC, TP> {
+        BasePredictionIterator {
+            extractor,
+            species_id,
+            sequence_id,
+            rc,
+            base_iter,
+            class_pred_iter,
+            phase_pred_iter,
+        }
     }
 
-    pub fn get_extractor(&self) -> &BasePredictionExtractor<TC, TP> { self.extractor }
+    pub fn get_extractor(&self) -> &BasePredictionExtractor<TC, TP> {
+        self.extractor
+    }
 
-    pub fn get_species_id(&self) -> SpeciesID { self.species_id }
+    pub fn get_species_id(&self) -> SpeciesID {
+        self.species_id
+    }
 
-    pub fn get_sequence_id(&self) -> SequenceID { self.sequence_id }
+    pub fn get_sequence_id(&self) -> SequenceID {
+        self.sequence_id
+    }
 
-    pub fn get_rc(&self) -> bool { self.rc }
+    pub fn get_rc(&self) -> bool {
+        self.rc
+    }
 }
 
-impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> Iterator for BasePredictionIterator<'a, TC, TP>
+impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> Iterator
+    for BasePredictionIterator<'a, TC, TP>
 {
     type Item = (Bases, ClassPrediction, PhasePrediction);
 
-    fn next(&mut self) -> Option<Self::Item>
-    {
+    fn next(&mut self) -> Option<Self::Item> {
         let bases = self.base_iter.next();
         let class_pred = self.class_pred_iter.next();
         let phase_pred = self.phase_pred_iter.next();
 
-        if bases.is_none() && class_pred.is_none() && phase_pred.is_none()
-        { return None }
+        if bases.is_none() && class_pred.is_none() && phase_pred.is_none() {
+            return None;
+        }
 
-        if bases.is_none() || class_pred.is_none() || phase_pred.is_none()
-        { panic!("Different lengths in base/class_pred/phase_pred iterators") }
+        if bases.is_none() || class_pred.is_none() || phase_pred.is_none() {
+            panic!("Different lengths in base/class_pred/phase_pred iterators")
+        }
 
         let bases = bases.expect("Unexpected end of base iter");
         let class_pred = class_pred.expect("Unexpected end of class_pred iter");
         let phase_pred = phase_pred.expect("Unexpected end of phase_pred iter");
 
-        return Some((bases, class_pred, phase_pred))
+        return Some((bases, class_pred, phase_pred));
     }
 }
 
-
-
-
-
 // Hard coded as Class/Phase reference/reference for now. Would make more sense to have all base-level datasets optionally available (and seekable)
-pub struct ComparisonExtractor<'a>
-{
+pub struct ComparisonExtractor<'a> {
     helixer_res: &'a HelixerResults,
 
     class_ref_blocked_dataset: Option<BlockedDataset2D<'a, i8, ClassReference>>,
@@ -141,57 +200,83 @@ pub struct ComparisonExtractor<'a>
     phase_pred_blocked_dataset: BlockedDataset2D<'a, f32, PhasePrediction>,
 }
 
-impl<'a> ComparisonExtractor<'a>
-{
-    pub fn new(helixer_res: &'a HelixerResults) -> Result<ComparisonExtractor<'a>>
-    {
+impl<'a> ComparisonExtractor<'a> {
+    pub fn new(helixer_res: &'a HelixerResults) -> Result<ComparisonExtractor<'a>> {
         let class_ref_blocked_dataset = helixer_res.get_class_reference()?;
         let phase_ref_blocked_dataset = helixer_res.get_phase_reference()?;
 
         let class_pred_blocked_dataset = helixer_res.get_class_predictions()?;
         let phase_pred_blocked_dataset = helixer_res.get_phase_predictions()?;
 
-        Ok(ComparisonExtractor { helixer_res, class_ref_blocked_dataset, phase_ref_blocked_dataset, class_pred_blocked_dataset, phase_pred_blocked_dataset })
+        Ok(ComparisonExtractor {
+            helixer_res,
+            class_ref_blocked_dataset,
+            phase_ref_blocked_dataset,
+            class_pred_blocked_dataset,
+            phase_pred_blocked_dataset,
+        })
     }
 
-    pub fn fwd_iterator(&'a self, sequence_id: SequenceID) -> ComparisonIterator<'a>
-    {
+    pub fn fwd_iterator(&'a self, sequence_id: SequenceID) -> ComparisonIterator<'a> {
         let sequence = self.helixer_res.get_index().get_sequence_by_id(sequence_id);
 
-        let class_ref_iter = self.class_ref_blocked_dataset.as_ref().map(|d| d.fwd_iter(sequence_id));
-        let phase_ref_iter = self.phase_ref_blocked_dataset.as_ref().map(|d| d.fwd_iter(sequence_id));
+        let class_ref_iter = self
+            .class_ref_blocked_dataset
+            .as_ref()
+            .map(|d| d.fwd_iter(sequence_id));
+        let phase_ref_iter = self
+            .phase_ref_blocked_dataset
+            .as_ref()
+            .map(|d| d.fwd_iter(sequence_id));
 
         let class_pred_iter = self.class_pred_blocked_dataset.fwd_iter(sequence_id);
         let phase_pred_iter = self.phase_pred_blocked_dataset.fwd_iter(sequence_id);
 
-        ComparisonIterator::new(self, sequence.get_species_id(), sequence_id, false,
-                                class_ref_iter, phase_ref_iter, class_pred_iter, phase_pred_iter)
+        ComparisonIterator::new(
+            self,
+            sequence.get_species_id(),
+            sequence_id,
+            false,
+            class_ref_iter,
+            phase_ref_iter,
+            class_pred_iter,
+            phase_pred_iter,
+        )
     }
 
-    pub fn rev_iterator(&'a self, sequence_id: SequenceID) -> ComparisonIterator<'a>
-    {
+    pub fn rev_iterator(&'a self, sequence_id: SequenceID) -> ComparisonIterator<'a> {
         let sequence = self.helixer_res.get_index().get_sequence_by_id(sequence_id);
 
-        let class_ref_iter = self.class_ref_blocked_dataset.as_ref().map(|d| d.rev_iter(sequence_id));
-        let phase_ref_iter = self.phase_ref_blocked_dataset.as_ref().map(|d| d.rev_iter(sequence_id));
+        let class_ref_iter = self
+            .class_ref_blocked_dataset
+            .as_ref()
+            .map(|d| d.rev_iter(sequence_id));
+        let phase_ref_iter = self
+            .phase_ref_blocked_dataset
+            .as_ref()
+            .map(|d| d.rev_iter(sequence_id));
 
         let class_pred_iter = self.class_pred_blocked_dataset.rev_iter(sequence_id);
         let phase_pred_iter = self.phase_pred_blocked_dataset.rev_iter(sequence_id);
 
-        ComparisonIterator::new(self, sequence.get_species_id(), sequence_id, true,
-                                class_ref_iter, phase_ref_iter, class_pred_iter, phase_pred_iter)
+        ComparisonIterator::new(
+            self,
+            sequence.get_species_id(),
+            sequence_id,
+            true,
+            class_ref_iter,
+            phase_ref_iter,
+            class_pred_iter,
+            phase_pred_iter,
+        )
     }
 
-    pub fn has_ref(&self) -> bool
-    {
+    pub fn has_ref(&self) -> bool {
         self.class_ref_blocked_dataset.is_some() && self.phase_ref_blocked_dataset.is_some()
     }
 }
 
-
-
-pub struct ComparisonIterator<'a>
-{
+pub struct ComparisonIterator<'a> {
     extractor: &'a ComparisonExtractor<'a>,
 
     species_id: SpeciesID,
@@ -207,67 +292,96 @@ pub struct ComparisonIterator<'a>
     phase_pred_iter: BlockedDataset2DIter<'a, f32, PhasePrediction>,
 }
 
-impl<'a> ComparisonIterator<'a>
-{
-    fn new(extractor: &'a ComparisonExtractor<'a>, species_id: SpeciesID, sequence_id: SequenceID, rc: bool,
-           class_ref_iter: Option<BlockedDataset2DIter<'a, i8, ClassReference>>, phase_ref_iter: Option<BlockedDataset2DIter<'a, i8, PhaseReference>>,
-           class_pred_iter: BlockedDataset2DIter<'a, f32, ClassPrediction>, phase_pred_iter: BlockedDataset2DIter<'a, f32, PhasePrediction>)
-           -> ComparisonIterator<'a>
-    {
+impl<'a> ComparisonIterator<'a> {
+    fn new(
+        extractor: &'a ComparisonExtractor<'a>,
+        species_id: SpeciesID,
+        sequence_id: SequenceID,
+        rc: bool,
+        class_ref_iter: Option<BlockedDataset2DIter<'a, i8, ClassReference>>,
+        phase_ref_iter: Option<BlockedDataset2DIter<'a, i8, PhaseReference>>,
+        class_pred_iter: BlockedDataset2DIter<'a, f32, ClassPrediction>,
+        phase_pred_iter: BlockedDataset2DIter<'a, f32, PhasePrediction>,
+    ) -> ComparisonIterator<'a> {
         let has_ref = extractor.has_ref();
-        ComparisonIterator { extractor, species_id, sequence_id, rc, has_ref, class_ref_iter, phase_ref_iter, class_pred_iter, phase_pred_iter }
+        ComparisonIterator {
+            extractor,
+            species_id,
+            sequence_id,
+            rc,
+            has_ref,
+            class_ref_iter,
+            phase_ref_iter,
+            class_pred_iter,
+            phase_pred_iter,
+        }
     }
 
-    pub fn get_extractor(&self) -> &ComparisonExtractor { self.extractor }
+    pub fn get_extractor(&self) -> &ComparisonExtractor {
+        self.extractor
+    }
 
-    pub fn get_species_id(&self) -> SpeciesID { self.species_id }
+    pub fn get_species_id(&self) -> SpeciesID {
+        self.species_id
+    }
 
-    pub fn get_sequence_id(&self) -> SequenceID { self.sequence_id }
+    pub fn get_sequence_id(&self) -> SequenceID {
+        self.sequence_id
+    }
 
-    pub fn get_rc(&self) -> bool { self.rc }
-
+    pub fn get_rc(&self) -> bool {
+        self.rc
+    }
 }
 
+impl<'a> Iterator for ComparisonIterator<'a> {
+    type Item = (
+        ClassReference,
+        PhaseReference,
+        ClassPrediction,
+        PhasePrediction,
+    );
 
-impl<'a> Iterator for ComparisonIterator<'a>
-{
-    type Item = (ClassReference, PhaseReference, ClassPrediction, PhasePrediction);
-
-    fn next(&mut self) -> Option<Self::Item>
-    {
+    fn next(&mut self) -> Option<Self::Item> {
         let class_pred = self.class_pred_iter.next();
         let phase_pred = self.phase_pred_iter.next();
 
-        let (class_ref, phase_ref) =
-            if self.has_ref
-                {
-                let class_ref = self.class_ref_iter.as_mut().unwrap().next();
-                let phase_ref = self.phase_ref_iter.as_mut().unwrap().next();
+        let (class_ref, phase_ref) = if self.has_ref {
+            let class_ref = self.class_ref_iter.as_mut().unwrap().next();
+            let phase_ref = self.phase_ref_iter.as_mut().unwrap().next();
 
-                if class_ref.is_none() && phase_ref.is_none() && class_pred.is_none() && phase_pred.is_none()
-                    { return None }
+            if class_ref.is_none()
+                && phase_ref.is_none()
+                && class_pred.is_none()
+                && phase_pred.is_none()
+            {
+                return None;
+            }
 
-                if class_ref.is_none() || phase_ref.is_none() || class_pred.is_none() || phase_pred.is_none()
-                    { panic!("Different lengths in class_ref/phase_ref/class_pred/phase_pred iterators") }
+            if class_ref.is_none()
+                || phase_ref.is_none()
+                || class_pred.is_none()
+                || phase_pred.is_none()
+            {
+                panic!("Different lengths in class_ref/phase_ref/class_pred/phase_pred iterators")
+            }
 
-                (class_ref.unwrap(), phase_ref.unwrap())
-                }
-            else
-                {
-                if class_pred.is_none() && phase_pred.is_none()
-                    { return None }
+            (class_ref.unwrap(), phase_ref.unwrap())
+        } else {
+            if class_pred.is_none() && phase_pred.is_none() {
+                return None;
+            }
 
-                if class_pred.is_none() || phase_pred.is_none()
-                    { panic!("Different lengths in class_pred/phase_pred iterators") }
+            if class_pred.is_none() || phase_pred.is_none() {
+                panic!("Different lengths in class_pred/phase_pred iterators")
+            }
 
-                (ClassReference::default(), PhaseReference::default())
-                };
+            (ClassReference::default(), PhaseReference::default())
+        };
 
         let class_pred = class_pred.unwrap();
         let phase_pred = phase_pred.unwrap();
 
-        return Some((class_ref, phase_ref, class_pred, phase_pred))
+        return Some((class_ref, phase_ref, class_pred, phase_pred));
     }
 }
-
-

--- a/helixer_post_bin/src/analysis/gff_conv.rs
+++ b/helixer_post_bin/src/analysis/gff_conv.rs
@@ -1,5 +1,3 @@
-
-
 /*
 
 Chr1    phytozomev10    gene    91376   95651   .       +       .       ID=AT1G01220.TAIR10;Name=AT1G01220
@@ -29,79 +27,112 @@ sequence: String, source: String, feature: GffFeature, start: u64, end: u64, sco
 
  */
 
-
-
-use crate::gff::{GffRecord, GffStrand, GffFeature, GffPhase};
-use crate::analysis::hmm::{HmmStateRegion, HmmAnnotationLabel};
+use crate::analysis::hmm::{HmmAnnotationLabel, HmmStateRegion};
+use crate::gff::{GffFeature, GffPhase, GffRecord, GffStrand};
 
 // generate gene, mRNA and exon records, based on UTR5/CDS/UTR3
-fn generate_gff_aggregate_records(recs: Vec<GffRecord>, sequence: &str, source: &str, strand: Option<GffStrand>, gene_name: &str) -> Vec<GffRecord>
-{
-    if recs.len()==0
-    { return Vec::new(); }
+fn generate_gff_aggregate_records(
+    recs: Vec<GffRecord>,
+    sequence: &str,
+    source: &str,
+    strand: Option<GffStrand>,
+    gene_name: &str,
+) -> Vec<GffRecord> {
+    if recs.len() == 0 {
+        return Vec::new();
+    }
 
-    let mut maybe_transcript_start : Option<u64> = None;
-    let mut maybe_transcript_end : Option<u64> = None;
+    let mut maybe_transcript_start: Option<u64> = None;
+    let mut maybe_transcript_end: Option<u64> = None;
 
-    let mut maybe_exon_start : Option<u64> = None;
-    let mut maybe_exon_end : Option<u64> = None;
+    let mut maybe_exon_start: Option<u64> = None;
+    let mut maybe_exon_end: Option<u64> = None;
 
     let mut exon_ranges = Vec::new();
 
-    for rec in recs.iter()
-    {
-        if maybe_transcript_start == None { maybe_transcript_start = Some(rec.get_start()); }
+    for rec in recs.iter() {
+        if maybe_transcript_start == None {
+            maybe_transcript_start = Some(rec.get_start());
+        }
         maybe_transcript_end = Some(rec.get_end());
 
-        if let (Some(exon_start), Some(exon_end)) = (maybe_exon_start, maybe_exon_end)
-        {
-            if exon_end+1 < rec.get_start()
-            {
+        if let (Some(exon_start), Some(exon_end)) = (maybe_exon_start, maybe_exon_end) {
+            if exon_end + 1 < rec.get_start() {
                 exon_ranges.push((exon_start, exon_end));
                 maybe_exon_start = None;
             }
         }
 
-        if maybe_exon_start == None { maybe_exon_start = Some(rec.get_start()); }
+        if maybe_exon_start == None {
+            maybe_exon_start = Some(rec.get_start());
+        }
         maybe_exon_end = Some(rec.get_end());
     }
 
-    if let (Some(exon_start), Some(exon_end)) = (maybe_exon_start, maybe_exon_end)
-    { exon_ranges.push((exon_start, exon_end)); }
-
+    if let (Some(exon_start), Some(exon_end)) = (maybe_exon_start, maybe_exon_end) {
+        exon_ranges.push((exon_start, exon_end));
+    }
 
     let transcript_start = maybe_transcript_start.unwrap();
     let transcript_end = maybe_transcript_end.unwrap();
 
-    let mut recs_out = Vec::with_capacity(2+recs.len()*2);
+    let mut recs_out = Vec::with_capacity(2 + recs.len() * 2);
 
     let gene_attributes = format!("ID={}", gene_name);
-    let gene_rec = GffRecord::new(sequence.to_owned(), source.to_owned(), GffFeature::Gene,
-                                  transcript_start, transcript_end, None, strand, None, gene_attributes);
+    let gene_rec = GffRecord::new(
+        sequence.to_owned(),
+        source.to_owned(),
+        GffFeature::Gene,
+        transcript_start,
+        transcript_end,
+        None,
+        strand,
+        None,
+        gene_attributes,
+    );
     recs_out.push(gene_rec);
 
     let mrna_attributes = format!("ID={}.1;Parent={}", gene_name, gene_name);
-    let mrna_rec = GffRecord::new(sequence.to_owned(), source.to_owned(), GffFeature::MRNA,
-                                  transcript_start, transcript_end, None, strand, None, mrna_attributes);
+    let mrna_rec = GffRecord::new(
+        sequence.to_owned(),
+        source.to_owned(),
+        GffFeature::MRNA,
+        transcript_start,
+        transcript_end,
+        None,
+        strand,
+        None,
+        mrna_attributes,
+    );
     recs_out.push(mrna_rec);
 
     let mut exon_range_iter = exon_ranges.into_iter();
     let mut current_exon_end = None;
     let mut exon_idx = 1;
 
-    for rec in recs
-    {
-        if current_exon_end.is_none() || current_exon_end.unwrap() < rec.get_start()
-        {
+    for rec in recs {
+        if current_exon_end.is_none() || current_exon_end.unwrap() < rec.get_start() {
             let (exon_start, exon_end) = exon_range_iter.next().unwrap();
-            let exon_attributes = format!("ID={}.1.exon.{};Parent={}.1", gene_name, exon_idx, gene_name);
+            let exon_attributes = format!(
+                "ID={}.1.exon.{};Parent={}.1",
+                gene_name, exon_idx, gene_name
+            );
 
-            let exon_rec = GffRecord::new(sequence.to_owned(), source.to_owned(), GffFeature::Exon,
-                                          exon_start, exon_end, None, strand, None, exon_attributes);
+            let exon_rec = GffRecord::new(
+                sequence.to_owned(),
+                source.to_owned(),
+                GffFeature::Exon,
+                exon_start,
+                exon_end,
+                None,
+                strand,
+                None,
+                exon_attributes,
+            );
 
             recs_out.push(exon_rec);
 
-            exon_idx+=1;
+            exon_idx += 1;
             current_exon_end = Some(exon_end);
         }
 
@@ -111,8 +142,14 @@ fn generate_gff_aggregate_records(recs: Vec<GffRecord>, sequence: &str, source: 
     recs_out
 }
 
-fn convert_regions_to_gff(regions: Vec<HmmStateRegion>, sequence: &str, source: &str, strand: Option<GffStrand>, position: usize, gene_name: &str) -> Vec<GffRecord>
-{
+fn convert_regions_to_gff(
+    regions: Vec<HmmStateRegion>,
+    sequence: &str,
+    source: &str,
+    strand: Option<GffStrand>,
+    position: usize,
+    gene_name: &str,
+) -> Vec<GffRecord> {
     let mut utr5_idx = 0;
     let mut cds_idx = 0;
     let mut utr3_idx = 0;
@@ -121,73 +158,116 @@ fn convert_regions_to_gff(regions: Vec<HmmStateRegion>, sequence: &str, source: 
 
     let mut region_vec = Vec::new();
 
-    for region in regions.iter()
-    {
-        let maybe_feature_and_attributes = match region.get_annotation_label()
-        {
+    for region in regions.iter() {
+        let maybe_feature_and_attributes = match region.get_annotation_label() {
             HmmAnnotationLabel::Intergenic => None, //panic!("Intergenic should be removed before now"),
-            HmmAnnotationLabel::UTR5 => { utr5_idx+=1; Some((GffFeature::FivePrimeUTR, format!("ID={}.1.five_prime_UTR.{};Parent={}.1", gene_name, utr5_idx, gene_name))) },
+            HmmAnnotationLabel::UTR5 => {
+                utr5_idx += 1;
+                Some((
+                    GffFeature::FivePrimeUTR,
+                    format!(
+                        "ID={}.1.five_prime_UTR.{};Parent={}.1",
+                        gene_name, utr5_idx, gene_name
+                    ),
+                ))
+            }
             HmmAnnotationLabel::Start => panic!("Start should be Coding"),
-            HmmAnnotationLabel::Coding => { cds_idx+=1; Some((GffFeature::CDS, format!("ID={}.1.CDS.{};Parent={}.1", gene_name, cds_idx, gene_name))) },
+            HmmAnnotationLabel::Coding => {
+                cds_idx += 1;
+                Some((
+                    GffFeature::CDS,
+                    format!("ID={}.1.CDS.{};Parent={}.1", gene_name, cds_idx, gene_name),
+                ))
+            }
             HmmAnnotationLabel::Intron => None,
             HmmAnnotationLabel::Stop => panic!("Stop should be Coding"),
-            HmmAnnotationLabel::UTR3 => { utr3_idx+=1; Some((GffFeature::ThreePrimeUTR, format!("ID={}.1.three_prime_UTR.{};Parent={}.1", gene_name, utr3_idx, gene_name))) }
+            HmmAnnotationLabel::UTR3 => {
+                utr3_idx += 1;
+                Some((
+                    GffFeature::ThreePrimeUTR,
+                    format!(
+                        "ID={}.1.three_prime_UTR.{};Parent={}.1",
+                        gene_name, utr3_idx, gene_name
+                    ),
+                ))
+            }
         };
 
-        if let Some((feature, attributes)) = maybe_feature_and_attributes
-        {
-            let start = (region.get_start_pos()+position+1) as u64;
-            let end = (region.get_end_pos()+position) as u64;
+        if let Some((feature, attributes)) = maybe_feature_and_attributes {
+            let start = (region.get_start_pos() + position + 1) as u64;
+            let end = (region.get_end_pos() + position) as u64;
 
-            let phase = if region.get_annotation_label() == HmmAnnotationLabel::Coding
-                { Some(GffPhase::from(coding_offset)) }
-            else
-                { None };
+            let phase = if region.get_annotation_label() == HmmAnnotationLabel::Coding {
+                Some(GffPhase::from(coding_offset))
+            } else {
+                None
+            };
 
             let rec = GffRecord::new(
-                sequence.to_owned(), source.to_owned(), feature, start, end, None, strand, phase, attributes);
+                sequence.to_owned(),
+                source.to_owned(),
+                feature,
+                start,
+                end,
+                None,
+                strand,
+                phase,
+                attributes,
+            );
 
             region_vec.push(rec);
 
-            if region.get_annotation_label() == HmmAnnotationLabel::Coding
-                { coding_offset+=region.len() as u64; }
+            if region.get_annotation_label() == HmmAnnotationLabel::Coding {
+                coding_offset += region.len() as u64;
+            }
         }
     }
 
     region_vec
 }
 
-
-pub fn hmm_solution_to_gff(genes: Vec<(Vec<HmmStateRegion>, usize)>, species: &str, sequence: &str, source: &str,
-                           rev: bool, position: usize, sequence_length: u64, min_coding_length: usize, gene_idx: &mut usize) -> Vec<GffRecord>
-{
-//        if genes.len() > 1
-//            { println!("{} genes at {} in {}", genes.len(), position, sequence); }
+pub fn hmm_solution_to_gff(
+    genes: Vec<(Vec<HmmStateRegion>, usize)>,
+    species: &str,
+    sequence: &str,
+    source: &str,
+    rev: bool,
+    position: usize,
+    sequence_length: u64,
+    min_coding_length: usize,
+    gene_idx: &mut usize,
+) -> Vec<GffRecord> {
+    //        if genes.len() > 1
+    //            { println!("{} genes at {} in {}", genes.len(), position, sequence); }
 
     let mut all_gff_recs = Vec::new();
 
     let strand = Some(GffStrand::Forward); // Initially generate everything as forward
 
-    for (gene_regions, coding_length) in genes
-        {
-        if coding_length >= min_coding_length
-            {
+    for (gene_regions, coding_length) in genes {
+        if coding_length >= min_coding_length {
             let gene_name = format!("{}_{}_{:06}", species, sequence, *gene_idx);
-            let gene_gff_recs = convert_regions_to_gff(gene_regions, sequence, source, strand, position, &gene_name);
-            let gene_gff_recs = generate_gff_aggregate_records(gene_gff_recs, sequence, source, strand, &gene_name);
+            let gene_gff_recs = convert_regions_to_gff(
+                gene_regions,
+                sequence,
+                source,
+                strand,
+                position,
+                &gene_name,
+            );
+            let gene_gff_recs =
+                generate_gff_aggregate_records(gene_gff_recs, sequence, source, strand, &gene_name);
 
             all_gff_recs.extend(gene_gff_recs);
             *gene_idx += 1;
-            }
         }
+    }
 
-    if rev
-    {
-        for gff_recs in all_gff_recs.iter_mut()
-            { gff_recs.swap_strand(sequence_length); }
+    if rev {
+        for gff_recs in all_gff_recs.iter_mut() {
+            gff_recs.swap_strand(sequence_length);
+        }
     }
 
     all_gff_recs
 }
-
-

--- a/helixer_post_bin/src/analysis/hmm.rs
+++ b/helixer_post_bin/src/analysis/hmm.rs
@@ -3,145 +3,178 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
 #[derive(Clone, Copy)]
-struct ClassPredPenalty
-{
-    penalty: [f64; 4] // Ordering is intergenic, utr, coding, intron
+struct ClassPredPenalty {
+    penalty: [f64; 4], // Ordering is intergenic, utr, coding, intron
 }
 
 #[allow(dead_code)]
-impl ClassPredPenalty
-{
-    pub fn get_intergenic_penalty(&self) -> f64 { self.penalty[0] }
+impl ClassPredPenalty {
+    pub fn get_intergenic_penalty(&self) -> f64 {
+        self.penalty[0]
+    }
 
-    pub fn get_utr_penalty(&self) -> f64 { self.penalty[1] }
+    pub fn get_utr_penalty(&self) -> f64 {
+        self.penalty[1]
+    }
 
-    pub fn get_coding_penalty(&self) -> f64 { self.penalty[2] }
+    pub fn get_coding_penalty(&self) -> f64 {
+        self.penalty[2]
+    }
 
-    pub fn get_intron_penalty(&self) -> f64 { self.penalty[3] }
+    pub fn get_intron_penalty(&self) -> f64 {
+        self.penalty[3]
+    }
 }
 
 const CLASS_PRED_PROB_FLOOR: f64 = 0.000_000_001; // Prevent infinite penalties
 
-impl From<&ClassPrediction> for ClassPredPenalty
-{
+impl From<&ClassPrediction> for ClassPredPenalty {
     fn from(pred: &ClassPrediction) -> Self {
-
         let raw_pred = pred.get();
 
-        let mut penalty = [0.0 ; 4];
-        for i in 0..4
-            {
+        let mut penalty = [0.0; 4];
+        for i in 0..4 {
             let adjusted_pred = raw_pred[i] as f64;
 
-            let adjusted_pred = if adjusted_pred > CLASS_PRED_PROB_FLOOR { adjusted_pred } else { CLASS_PRED_PROB_FLOOR };
+            let adjusted_pred = if adjusted_pred > CLASS_PRED_PROB_FLOOR {
+                adjusted_pred
+            } else {
+                CLASS_PRED_PROB_FLOOR
+            };
             penalty[i] = -f64::log2(adjusted_pred);
-            }
+        }
 
         let mut min_penalty = penalty[0];
-        for i in 1..4
-            { if penalty[i] < min_penalty { min_penalty = penalty[i] } }
+        for i in 1..4 {
+            if penalty[i] < min_penalty {
+                min_penalty = penalty[i]
+            }
+        }
 
-
-        for i in 0..4
-            { penalty[i]-=min_penalty; }
+        for i in 0..4 {
+            penalty[i] -= min_penalty;
+        }
 
         ClassPredPenalty { penalty }
     }
 }
 
-
 #[derive(Clone, Copy)]
-struct PhasePredPenalty
-{
-    penalty: [f64; 4] // Ordering is non-coding, phase 0, phase 1, phase 2
+struct PhasePredPenalty {
+    penalty: [f64; 4], // Ordering is non-coding, phase 0, phase 1, phase 2
 }
 
 #[allow(dead_code)]
-impl PhasePredPenalty
-{
-    pub fn get_non_coding_penalty(&self) -> f64 { self.penalty[0] }
+impl PhasePredPenalty {
+    pub fn get_non_coding_penalty(&self) -> f64 {
+        self.penalty[0]
+    }
 
-    pub fn get_phase0_penalty(&self) -> f64 { self.penalty[1] }
+    pub fn get_phase0_penalty(&self) -> f64 {
+        self.penalty[1]
+    }
 
-    pub fn get_phase1_penalty(&self) -> f64 { self.penalty[2] }
+    pub fn get_phase1_penalty(&self) -> f64 {
+        self.penalty[2]
+    }
 
-    pub fn get_phase2_penalty(&self) -> f64 { self.penalty[3] }
+    pub fn get_phase2_penalty(&self) -> f64 {
+        self.penalty[3]
+    }
 }
 
 const PHASE_PRED_PROB_FLOOR: f64 = 0.000_000_001; // Prevent infinite penalties
-//const PHASE_PRED_PROB_FLOOR: f64 = 0.5; // Limit impact of incorrect phase
+                                                  //const PHASE_PRED_PROB_FLOOR: f64 = 0.5; // Limit impact of incorrect phase
 
-impl From<&PhasePrediction> for PhasePredPenalty
-{
+impl From<&PhasePrediction> for PhasePredPenalty {
     fn from(pred: &PhasePrediction) -> Self {
-
         let raw_pred = pred.get();
 
-        let mut penalty = [0.0 ; 4];
-        for i in 0..4
-        {
+        let mut penalty = [0.0; 4];
+        for i in 0..4 {
             let adjusted_pred = raw_pred[i] as f64;
 
-            let adjusted_pred = if adjusted_pred > PHASE_PRED_PROB_FLOOR { adjusted_pred } else { PHASE_PRED_PROB_FLOOR };
+            let adjusted_pred = if adjusted_pred > PHASE_PRED_PROB_FLOOR {
+                adjusted_pred
+            } else {
+                PHASE_PRED_PROB_FLOOR
+            };
             penalty[i] = -f64::log2(adjusted_pred);
         }
 
         let mut min_penalty = penalty[0];
-        for i in 1..4
-        { if penalty[i] < min_penalty { min_penalty = penalty[i] } }
+        for i in 1..4 {
+            if penalty[i] < min_penalty {
+                min_penalty = penalty[i]
+            }
+        }
 
-        for i in 0..4
-        { penalty[i]-=min_penalty; }
+        for i in 0..4 {
+            penalty[i] -= min_penalty;
+        }
 
         PhasePredPenalty { penalty }
     }
 }
 
-
 #[derive(Clone, Copy)]
-struct PredPenalty
-{
-    penalty: [f64; 6] // Ordering is intergenic, utr, coding_phase0, coding_phase1, coding_phase2, intron
+struct PredPenalty {
+    penalty: [f64; 6], // Ordering is intergenic, utr, coding_phase0, coding_phase1, coding_phase2, intron
 }
 
 #[allow(dead_code)]
-impl PredPenalty
-{
-    pub fn get_intergenic_penalty(&self) -> f64 { self.penalty[0] }
+impl PredPenalty {
+    pub fn get_intergenic_penalty(&self) -> f64 {
+        self.penalty[0]
+    }
 
-    pub fn get_utr_penalty(&self) -> f64 { self.penalty[1] }
+    pub fn get_utr_penalty(&self) -> f64 {
+        self.penalty[1]
+    }
 
-    pub fn get_coding_phase0_penalty(&self) -> f64 { self.penalty[2] }
+    pub fn get_coding_phase0_penalty(&self) -> f64 {
+        self.penalty[2]
+    }
 
-    pub fn get_coding_phase1_penalty(&self) -> f64 { self.penalty[3] }
+    pub fn get_coding_phase1_penalty(&self) -> f64 {
+        self.penalty[3]
+    }
 
-    pub fn get_coding_phase2_penalty(&self) -> f64 { self.penalty[4] }
+    pub fn get_coding_phase2_penalty(&self) -> f64 {
+        self.penalty[4]
+    }
 
-    pub fn get_intron_penalty(&self) -> f64 { self.penalty[5] }
+    pub fn get_intron_penalty(&self) -> f64 {
+        self.penalty[5]
+    }
 }
 
-const PHASE_RETAIN: f64 = 0.20;      // Adjust as needed
+const PHASE_RETAIN: f64 = 0.20; // Adjust as needed
 
 const PHASE_DILUTE: f64 = 1.0 - PHASE_RETAIN;
-const PRED_PROB_FLOOR: f64 =  0.000_000_001; // Prevent infinite penalties
+const PRED_PROB_FLOOR: f64 = 0.000_000_001; // Prevent infinite penalties
 
-impl From<(&ClassPrediction, &PhasePrediction)> for PredPenalty
-{
+impl From<(&ClassPrediction, &PhasePrediction)> for PredPenalty {
     fn from((class_pred, phase_pred): (&ClassPrediction, &PhasePrediction)) -> Self {
-
         let phase0 = phase_pred.get_phase0() as f64;
         let phase1 = phase_pred.get_phase1() as f64;
         let phase2 = phase_pred.get_phase2() as f64;
 
         // Approach 1: rescale total phase to match coding and blend to dilution target (mean coding or total coding)
         let coding = class_pred.get_coding() as f64;
-        let total_coding_phase = phase0+phase1+phase2;
-        let (phase0, phase1, phase2) = if total_coding_phase > 0.0  // Prevent div by zero risk
-            {
+        let total_coding_phase = phase0 + phase1 + phase2;
+        let (phase0, phase1, phase2) = if total_coding_phase > 0.0
+        // Prevent div by zero risk
+        {
             let phase_scale = coding / total_coding_phase;
-            (phase0 * phase_scale, phase1 * phase_scale, phase2 * phase_scale)
-            }
-        else { ( coding / 3.0, coding / 3.0, coding / 3.0 ) };
+            (
+                phase0 * phase_scale,
+                phase1 * phase_scale,
+                phase2 * phase_scale,
+            )
+        } else {
+            (coding / 3.0, coding / 3.0, coding / 3.0)
+        };
 
         //let dilution_target = coding / 3.0;
         let dilution_target = coding;
@@ -151,248 +184,250 @@ impl From<(&ClassPrediction, &PhasePrediction)> for PredPenalty
         let phase2 = phase2 * PHASE_RETAIN + dilution_target * PHASE_DILUTE;
 
         /*
-        // Approach 2: rescale total phase to 1, dilute towards 1, then scale by coding
-        let total_coding_phase = phase0+phase1+phase2;
-        let (phase0, phase1, phase2) = if total_coding_phase > 0.0  // Prevent div by zero risk
-            {
-            let phase_scale = 1.0 / total_coding_phase;
-            (phase0 * phase_scale, phase1 * phase_scale, phase2 * phase_scale)
-            }
-        else { ( 1.0/3.0, 1.0/3.0, 1.0/3.0 ) };
+                // Approach 2: rescale total phase to 1, dilute towards 1, then scale by coding
+                let total_coding_phase = phase0+phase1+phase2;
+                let (phase0, phase1, phase2) = if total_coding_phase > 0.0  // Prevent div by zero risk
+                    {
+                    let phase_scale = 1.0 / total_coding_phase;
+                    (phase0 * phase_scale, phase1 * phase_scale, phase2 * phase_scale)
+                    }
+                else { ( 1.0/3.0, 1.0/3.0, 1.0/3.0 ) };
 
-        let coding = class_pred.get_coding() as f64;
-        let phase0 = (phase0 * PHASE_RETAIN + 1.0 * PHASE_DILUTE) * coding;
-        let phase1 = (phase1 * PHASE_RETAIN + 1.0 * PHASE_DILUTE) * coding;
-        let phase2 = (phase2 * PHASE_RETAIN + 1.0 * PHASE_DILUTE) * coding;
-*/
+                let coding = class_pred.get_coding() as f64;
+                let phase0 = (phase0 * PHASE_RETAIN + 1.0 * PHASE_DILUTE) * coding;
+                let phase1 = (phase1 * PHASE_RETAIN + 1.0 * PHASE_DILUTE) * coding;
+                let phase2 = (phase2 * PHASE_RETAIN + 1.0 * PHASE_DILUTE) * coding;
+        */
 
         // Convert to combined prob (not necessarily 1-hot)
-        let raw_probs = [class_pred.get_intergenic() as f64, class_pred.get_utr() as f64, phase0, phase1, phase2, class_pred.get_intron() as f64];
+        let raw_probs = [
+            class_pred.get_intergenic() as f64,
+            class_pred.get_utr() as f64,
+            phase0,
+            phase1,
+            phase2,
+            class_pred.get_intron() as f64,
+        ];
 
         // Calculate penalty from probs
-        let mut penalty = [0.0 ; 6];
-        for i in 0..6
-        {
+        let mut penalty = [0.0; 6];
+        for i in 0..6 {
             let adjusted_pred = raw_probs[i];
 
-            let adjusted_pred = if adjusted_pred > PRED_PROB_FLOOR { adjusted_pred } else { PRED_PROB_FLOOR };
+            let adjusted_pred = if adjusted_pred > PRED_PROB_FLOOR {
+                adjusted_pred
+            } else {
+                PRED_PROB_FLOOR
+            };
             penalty[i] = -f64::log2(adjusted_pred);
         }
 
         let mut min_penalty = penalty[0];
-        for i in 1..6
-            { if penalty[i] < min_penalty { min_penalty = penalty[i] } }
+        for i in 1..6 {
+            if penalty[i] < min_penalty {
+                min_penalty = penalty[i]
+            }
+        }
 
-        for i in 0..6
-            { penalty[i]-=min_penalty; }
+        for i in 0..6 {
+            penalty[i] -= min_penalty;
+        }
 
         PredPenalty { penalty }
     }
-
 }
-
 
 const BASE_PROB_FLOOR: f64 = 0.000_000_001; // Prevent infinite penalties
 
 #[derive(Clone, Copy)]
-pub struct BasesPenalty
-{
-    penalty: [f64; 4] // Ordering is C, A, T, G
+pub struct BasesPenalty {
+    penalty: [f64; 4], // Ordering is C, A, T, G
 }
 
-fn min2(a: f64, b: f64) -> f64
-{
-    if a < b { a } else { b }
+fn min2(a: f64, b: f64) -> f64 {
+    if a < b {
+        a
+    } else {
+        b
+    }
 }
 
-fn min3(a: f64, b: f64, c: f64) -> f64
-{
+fn min3(a: f64, b: f64, c: f64) -> f64 {
     let ab = if a < b { a } else { b };
-    if ab < c { ab } else { c }
+    if ab < c {
+        ab
+    } else {
+        c
+    }
 }
 
-
-impl BasesPenalty
-{
-    pub fn get_c(&self) -> f64
-    {
+impl BasesPenalty {
+    pub fn get_c(&self) -> f64 {
         self.penalty[0]
     }
 
-    pub fn get_a(&self) -> f64
-    {
+    pub fn get_a(&self) -> f64 {
         self.penalty[1]
     }
 
-    pub fn get_t(&self) -> f64 { self.penalty[2] }
+    pub fn get_t(&self) -> f64 {
+        self.penalty[2]
+    }
 
-    pub fn get_g(&self) -> f64
-    {
+    pub fn get_g(&self) -> f64 {
         self.penalty[3]
     }
 
-
-
-
-    pub fn as_str(&self) -> char
-    {
-        if self.penalty[0]<BASE_PROB_FLOOR
-            { 'C' }
-        else if self.penalty[1]<BASE_PROB_FLOOR
-            { 'A' }
-        else if self.penalty[2]<BASE_PROB_FLOOR
-            { 'T' }
-        else
-            { 'G' }
+    pub fn as_str(&self) -> char {
+        if self.penalty[0] < BASE_PROB_FLOOR {
+            'C'
+        } else if self.penalty[1] < BASE_PROB_FLOOR {
+            'A'
+        } else if self.penalty[2] < BASE_PROB_FLOOR {
+            'T'
+        } else {
+            'G'
+        }
     }
 }
 
-impl From<&Bases> for BasesPenalty
-{
+impl From<&Bases> for BasesPenalty {
     fn from(bases: &Bases) -> Self {
-
         let raw_bases = bases.get();
 
-        let mut penalty = [0.0 ; 4];
-        for i in 0..4
-        {
+        let mut penalty = [0.0; 4];
+        for i in 0..4 {
             let adjusted_base = raw_bases[i] as f64;
 
-            let adjusted_base = if adjusted_base > BASE_PROB_FLOOR { adjusted_base } else { BASE_PROB_FLOOR };
+            let adjusted_base = if adjusted_base > BASE_PROB_FLOOR {
+                adjusted_base
+            } else {
+                BASE_PROB_FLOOR
+            };
             penalty[i] = -f64::log2(adjusted_base);
         }
 
         let mut min_penalty = penalty[0];
-        for i in 1..4
-            { if penalty[i] < min_penalty { min_penalty = penalty[i] } }
+        for i in 1..4 {
+            if penalty[i] < min_penalty {
+                min_penalty = penalty[i]
+            }
+        }
 
-
-        for i in 0..4
-            { penalty[i]-=min_penalty; }
+        for i in 0..4 {
+            penalty[i] -= min_penalty;
+        }
 
         BasesPenalty { penalty }
     }
-
 }
 
-
-struct TransitionContext<'a>
-{
+struct TransitionContext<'a> {
     class_pred_pen: &'a [ClassPredPenalty],
     phase_pred_pen: &'a [PhasePredPenalty],
     pred_pen: &'a [PredPenalty],
 
     base_pen: &'a [BasesPenalty],
-    offset: usize
+    offset: usize,
 }
 
 #[allow(dead_code)]
-impl<'a> TransitionContext<'a>
-{
-    fn new(class_pred_pen: &'a [ClassPredPenalty], phase_pred_pen: &'a [PhasePredPenalty], pred_pen: &'a [PredPenalty], base_pen: &'a [BasesPenalty], offset: usize) -> TransitionContext<'a>
-    {
-        TransitionContext { class_pred_pen, phase_pred_pen, pred_pen, base_pen, offset}
+impl<'a> TransitionContext<'a> {
+    fn new(
+        class_pred_pen: &'a [ClassPredPenalty],
+        phase_pred_pen: &'a [PhasePredPenalty],
+        pred_pen: &'a [PredPenalty],
+        base_pen: &'a [BasesPenalty],
+        offset: usize,
+    ) -> TransitionContext<'a> {
+        TransitionContext {
+            class_pred_pen,
+            phase_pred_pen,
+            pred_pen,
+            base_pen,
+            offset,
+        }
     }
 
-    fn get_class_pred(&self, position: usize) -> Option<&ClassPredPenalty>
-    {
+    fn get_class_pred(&self, position: usize) -> Option<&ClassPredPenalty> {
         self.class_pred_pen.get(self.offset + position)
     }
 
-    fn get_phase_pred(&self, position: usize) -> Option<&PhasePredPenalty>
-    {
+    fn get_phase_pred(&self, position: usize) -> Option<&PhasePredPenalty> {
         self.phase_pred_pen.get(self.offset + position)
     }
 
-    fn get_pred(&self, position: usize) -> Option<&PredPenalty>
-    {
+    fn get_pred(&self, position: usize) -> Option<&PredPenalty> {
         self.pred_pen.get(self.offset + position)
     }
 
     /*
-    fn get_upstream(&self, len: usize) -> Option<&[BasesPenalty]>
-    {
-        if len <= self.offset
-            { Some(&self.base_pen[self.offset-len .. self.offset]) }
-        else { None }
-    }
-*/
-
-    fn get_downstream(&self, len: usize) -> Option<&[BasesPenalty]>
-    {
-        if self.offset + len <= self.base_pen.len()
-        { Some(&self.base_pen[self.offset .. self.offset + len]) }
-        else
-        { None }
-    }
-
-    fn get_ctx(&self, ulen: usize, dlen: usize) -> Option<&[BasesPenalty]>
-    {
-        if ulen <= self.offset && self.offset + dlen <= self.base_pen.len()
-        { Some(&self.base_pen[self.offset-ulen .. self.offset + dlen]) }
-        else
-        { None }
-    }
-
-    fn get_donor_penalty_u2_gt_ag(&self, can_splice: bool) -> Option<f64>
-    {
-        if let (Some(ds), true) = (self.get_ctx(0, 2), can_splice)
+        fn get_upstream(&self, len: usize) -> Option<&[BasesPenalty]>
         {
-            let pen =
-                ds[0].get_g() +
-                ds[1].get_t();
+            if len <= self.offset
+                { Some(&self.base_pen[self.offset-len .. self.offset]) }
+            else { None }
+        }
+    */
+
+    fn get_downstream(&self, len: usize) -> Option<&[BasesPenalty]> {
+        if self.offset + len <= self.base_pen.len() {
+            Some(&self.base_pen[self.offset..self.offset + len])
+        } else {
+            None
+        }
+    }
+
+    fn get_ctx(&self, ulen: usize, dlen: usize) -> Option<&[BasesPenalty]> {
+        if ulen <= self.offset && self.offset + dlen <= self.base_pen.len() {
+            Some(&self.base_pen[self.offset - ulen..self.offset + dlen])
+        } else {
+            None
+        }
+    }
+
+    fn get_donor_penalty_u2_gt_ag(&self, can_splice: bool) -> Option<f64> {
+        if let (Some(ds), true) = (self.get_ctx(0, 2), can_splice) {
+            let pen = ds[0].get_g() + ds[1].get_t();
             Some(pen * DONOR_WEIGHT + DONOR_U2_GT_AG_FIXED_PENALTY)
+        } else {
+            None
         }
-        else
-        { None }
     }
 
-    fn get_acceptor_penalty_u2_gt_ag(&self) -> Option<f64>
-    {
-        if let Some(us) = self.get_ctx(2,0)
-        {
-            let pen =
-                us[0].get_a() +
-                us[1].get_g();
-            Some(pen*ACCEPTOR_WEIGHT)
+    fn get_acceptor_penalty_u2_gt_ag(&self) -> Option<f64> {
+        if let Some(us) = self.get_ctx(2, 0) {
+            let pen = us[0].get_a() + us[1].get_g();
+            Some(pen * ACCEPTOR_WEIGHT)
+        } else {
+            None
         }
-        else
-        { None }
     }
 
-    fn get_donor_penalty_u2_gc_ag(&self, can_splice: bool) -> Option<f64>
-    {
-        if let (Some(ds), true) = (self.get_ctx(2, 2), can_splice)
-        {
+    fn get_donor_penalty_u2_gc_ag(&self, can_splice: bool) -> Option<f64> {
+        if let (Some(ds), true) = (self.get_ctx(2, 2), can_splice) {
             let pen =
                 //ds[0].get_a() +
                 ds[1].get_g() +
                 ds[2].get_g() +
                 ds[3].get_c();
             Some(pen * DONOR_WEIGHT + DONOR_U2_GC_AG_FIXED_PENALTY)
+        } else {
+            None
         }
-        else
-        { None }
     }
 
-    fn get_acceptor_penalty_u2_gc_ag(&self) -> Option<f64>
-    {
-        if let Some(us) = self.get_ctx(2,0)
-        {
-            let pen =
-                us[0].get_a() +
-                us[1].get_g();
-            Some(pen*ACCEPTOR_WEIGHT)
+    fn get_acceptor_penalty_u2_gc_ag(&self) -> Option<f64> {
+        if let Some(us) = self.get_ctx(2, 0) {
+            let pen = us[0].get_a() + us[1].get_g();
+            Some(pen * ACCEPTOR_WEIGHT)
+        } else {
+            None
         }
-        else
-        { None }
     }
 
-
-    fn get_donor_penalty_u12_at_ac(&self, can_splice: bool) -> Option<f64>
-    {
-        if let (Some(ds), true) = (self.get_ctx(0, 7), can_splice)
-        {
+    fn get_donor_penalty_u12_at_ac(&self, can_splice: bool) -> Option<f64> {
+        if let (Some(ds), true) = (self.get_ctx(0, 7), can_splice) {
             let pen = // ATATCCT
                 ds[0].get_a() +
                 ds[1].get_t() +
@@ -403,34 +438,24 @@ impl<'a> TransitionContext<'a>
                 ds[6].get_t();
 
             Some(pen * DONOR_WEIGHT + DONOR_U12_AT_AC_FIXED_PENALTY)
+        } else {
+            None
         }
-        else
-        { None }
     }
 
-    fn get_acceptor_penalty_u12_at_ac(&self) -> Option<f64>
-    {
-        if let Some(us) = self.get_ctx(2,0)
-        {
-            let pen =
-                us[0].get_a() +
-                us[1].get_c();
-            Some(pen*ACCEPTOR_WEIGHT)
+    fn get_acceptor_penalty_u12_at_ac(&self) -> Option<f64> {
+        if let Some(us) = self.get_ctx(2, 0) {
+            let pen = us[0].get_a() + us[1].get_c();
+            Some(pen * ACCEPTOR_WEIGHT)
+        } else {
+            None
         }
-        else
-        { None }
     }
 }
 
-
-
-
-
-
 #[allow(dead_code)]
 #[derive(Clone, Copy, Eq, PartialEq)]
-pub enum HmmAnnotationLabel
-{
+pub enum HmmAnnotationLabel {
     Intergenic,
     UTR5,
     Start,
@@ -440,12 +465,9 @@ pub enum HmmAnnotationLabel
     UTR3,
 }
 
-impl HmmAnnotationLabel
-{
-    pub fn to_str(&self) -> &str
-    {
-        match self
-        {
+impl HmmAnnotationLabel {
+    pub fn to_str(&self) -> &str {
+        match self {
             HmmAnnotationLabel::Intergenic => "Intergenic",
             HmmAnnotationLabel::UTR5 => "UTR5",
             HmmAnnotationLabel::Start => "Start",
@@ -457,10 +479,8 @@ impl HmmAnnotationLabel
     }
 }
 
-
 #[derive(Clone, Copy, Eq, PartialEq)]
-enum HmmPrimaryState
-{
+enum HmmPrimaryState {
     Intergenic,
     UTR5,
     Start0, // Possible Start - After A
@@ -469,19 +489,16 @@ enum HmmPrimaryState
     Coding0,
     Coding1,
     Coding2,
-    Stop0T, // Possible Stop - After T
+    Stop0T,  // Possible Stop - After T
     Stop1TA, // Possible Stop - After TA
     Stop1TG, // Possible Stop - After TG
-    Stop2, // Possible Stop - After TAA / TAG / TGA
-    UTR3
+    Stop2,   // Possible Stop - After TAA / TAG / TGA
+    UTR3,
 }
 
-impl HmmPrimaryState
-{
-    pub fn to_str(&self) -> &str
-    {
-        match self
-        {
+impl HmmPrimaryState {
+    pub fn to_str(&self) -> &str {
+        match self {
             HmmPrimaryState::Intergenic => "Intergenic",
             HmmPrimaryState::UTR5 => "UTR5",
             HmmPrimaryState::Start0 => "Start0",
@@ -500,12 +517,11 @@ impl HmmPrimaryState
 }
 
 #[derive(Clone, Copy, Eq, PartialEq)]
-enum HmmIntronState
-{
+enum HmmIntronState {
     None = 0,
     U2GtAgDSS = 1,
-    U2GtAg = 2 ,
-    U2GcAgDSS = 3 ,
+    U2GtAg = 2,
+    U2GcAgDSS = 3,
     U2GcAg = 4,
     U12AtAcDSS = 5,
     U12AtAc = 6,
@@ -513,12 +529,9 @@ enum HmmIntronState
 
 //const HMM_INTRON_STATES: usize = 7;
 
-impl HmmIntronState
-{
-    pub fn to_str(&self) -> &str
-    {
-        match self
-        {
+impl HmmIntronState {
+    pub fn to_str(&self) -> &str {
+        match self {
             HmmIntronState::None => "None",
             HmmIntronState::U2GtAgDSS => "U2GtAgDSS",
             HmmIntronState::U2GtAg => "U2GtAg",
@@ -530,13 +543,10 @@ impl HmmIntronState
     }
 }
 
-
-
 const HMM_STATES: usize = 73;
 
 #[derive(Clone, Copy, Eq, PartialEq, Ord)]
-enum HmmState
-{
+enum HmmState {
     Intergenic = 0,
 
     UTR5 = 1,
@@ -621,13 +631,11 @@ enum HmmState
     UTR3IntronU2GcAgDSS = 69,
     UTR3IntronU2GcAg = 70,
     UTR3IntronU12AtAcDSS = 71,
-    UTR3IntronU12AtAc = 72
+    UTR3IntronU12AtAc = 72,
 }
 
-impl std::cmp::PartialOrd for HmmState
-{
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering>
-    {
+impl std::cmp::PartialOrd for HmmState {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         let s = *self as u8;
         let o = *other as u8;
 
@@ -660,34 +668,49 @@ const ACCEPTOR_WEIGHT: f64 = 1.0;
 
 const STOP_WEIGHT: f64 = 1_000.0;
 
-pub fn show_hmm_config()
-{
+pub fn show_hmm_config() {
     println!("HMM Config");
-    println!("  Splicing Flags: U:{} US:{} S:{} SC:{} C:{} CS:{} S:{} SU:{} U:{}",
-             CAN_SPLICE_UTR5, CAN_SPLICE_UTR5_START, CAN_SPLICE_START,
-             CAN_SPLICE_START_CODING, CAN_SPLICE_CODING, CAN_SPLICE_CODING_STOP,
-             CAN_SPLICE_STOP, CAN_SPLICE_STOP_UTR3, CAN_SPLICE_UTR3);
+    println!(
+        "  Splicing Flags: U:{} US:{} S:{} SC:{} C:{} CS:{} S:{} SU:{} U:{}",
+        CAN_SPLICE_UTR5,
+        CAN_SPLICE_UTR5_START,
+        CAN_SPLICE_START,
+        CAN_SPLICE_START_CODING,
+        CAN_SPLICE_CODING,
+        CAN_SPLICE_CODING_STOP,
+        CAN_SPLICE_STOP,
+        CAN_SPLICE_STOP_UTR3,
+        CAN_SPLICE_UTR3
+    );
 
-    println!("  Splicing - Weights: Donor {}, Acceptor {}", DONOR_WEIGHT, ACCEPTOR_WEIGHT);
-    println!("  Splicing - Fixed Penalties: U2-GT-AG {}, U2-GT-AC {} U12-GT-AG {} U12-AT-AC {}",
-             DONOR_U2_GT_AG_FIXED_PENALTY, DONOR_U2_GC_AG_FIXED_PENALTY, DONOR_U12_GT_AG_FIXED_PENALTY, DONOR_U12_AT_AC_FIXED_PENALTY);
+    println!(
+        "  Splicing - Weights: Donor {}, Acceptor {}",
+        DONOR_WEIGHT, ACCEPTOR_WEIGHT
+    );
+    println!(
+        "  Splicing - Fixed Penalties: U2-GT-AG {}, U2-GT-AC {} U12-GT-AG {} U12-AT-AC {}",
+        DONOR_U2_GT_AG_FIXED_PENALTY,
+        DONOR_U2_GC_AG_FIXED_PENALTY,
+        DONOR_U12_GT_AG_FIXED_PENALTY,
+        DONOR_U12_AT_AC_FIXED_PENALTY
+    );
 
-    println!("  Coding - Weights: Start {}, Stop {}", START_WEIGHT, STOP_WEIGHT);
+    println!(
+        "  Coding - Weights: Start {}, Stop {}",
+        START_WEIGHT, STOP_WEIGHT
+    );
     //println!("  Phase Mode: Off");
     //println!("  Phase Mode: Additive, with {} prob floor", PHASE_PRED_PROB_FLOOR);
-    println!("  Phase Mode: Implementation 1, Dilute to Total, Retention: {}", PHASE_RETAIN);
+    println!(
+        "  Phase Mode: Implementation 1, Dilute to Total, Retention: {}",
+        PHASE_RETAIN
+    );
     println!();
 }
 
-
-
-
-impl HmmState
-{
-    fn get_component_states(self) -> (HmmPrimaryState, HmmIntronState)
-    {
-        match self
-        {
+impl HmmState {
+    fn get_component_states(self) -> (HmmPrimaryState, HmmIntronState) {
+        match self {
             HmmState::Intergenic => (HmmPrimaryState::Intergenic, HmmIntronState::None),
 
             HmmState::UTR5 => (HmmPrimaryState::UTR5, HmmIntronState::None),
@@ -703,7 +726,9 @@ impl HmmState
             HmmState::Start0IntronU2GtAg => (HmmPrimaryState::Start0, HmmIntronState::U2GtAg),
             HmmState::Start0IntronU2GcAgDSS => (HmmPrimaryState::Start0, HmmIntronState::U2GcAgDSS),
             HmmState::Start0IntronU2GcAg => (HmmPrimaryState::Start0, HmmIntronState::U2GcAg),
-            HmmState::Start0IntronU12AtAcDSS => (HmmPrimaryState::Start0, HmmIntronState::U12AtAcDSS),
+            HmmState::Start0IntronU12AtAcDSS => {
+                (HmmPrimaryState::Start0, HmmIntronState::U12AtAcDSS)
+            }
             HmmState::Start0IntronU12AtAc => (HmmPrimaryState::Start0, HmmIntronState::U12AtAc),
 
             HmmState::Start1 => (HmmPrimaryState::Start1, HmmIntronState::None),
@@ -711,33 +736,53 @@ impl HmmState
             HmmState::Start1IntronU2GtAg => (HmmPrimaryState::Start1, HmmIntronState::U2GtAg),
             HmmState::Start1IntronU2GcAgDSS => (HmmPrimaryState::Start1, HmmIntronState::U2GcAgDSS),
             HmmState::Start1IntronU2GcAg => (HmmPrimaryState::Start1, HmmIntronState::U2GcAg),
-            HmmState::Start1IntronU12AtAcDSS => (HmmPrimaryState::Start1, HmmIntronState::U12AtAcDSS),
+            HmmState::Start1IntronU12AtAcDSS => {
+                (HmmPrimaryState::Start1, HmmIntronState::U12AtAcDSS)
+            }
             HmmState::Start1IntronU12AtAc => (HmmPrimaryState::Start1, HmmIntronState::U12AtAc),
 
             HmmState::Start2 => (HmmPrimaryState::Start2, HmmIntronState::None),
 
             HmmState::Coding0 => (HmmPrimaryState::Coding0, HmmIntronState::None),
-            HmmState::Coding0IntronU2GtAgDSS => (HmmPrimaryState::Coding0, HmmIntronState::U2GtAgDSS),
+            HmmState::Coding0IntronU2GtAgDSS => {
+                (HmmPrimaryState::Coding0, HmmIntronState::U2GtAgDSS)
+            }
             HmmState::Coding0IntronU2GtAg => (HmmPrimaryState::Coding0, HmmIntronState::U2GtAg),
-            HmmState::Coding0IntronU2GcAgDSS => (HmmPrimaryState::Coding0, HmmIntronState::U2GcAgDSS),
+            HmmState::Coding0IntronU2GcAgDSS => {
+                (HmmPrimaryState::Coding0, HmmIntronState::U2GcAgDSS)
+            }
             HmmState::Coding0IntronU2GcAg => (HmmPrimaryState::Coding0, HmmIntronState::U2GcAg),
-            HmmState::Coding0IntronU12AtAcDSS => (HmmPrimaryState::Coding0, HmmIntronState::U12AtAcDSS),
+            HmmState::Coding0IntronU12AtAcDSS => {
+                (HmmPrimaryState::Coding0, HmmIntronState::U12AtAcDSS)
+            }
             HmmState::Coding0IntronU12AtAc => (HmmPrimaryState::Coding0, HmmIntronState::U12AtAc),
 
             HmmState::Coding1 => (HmmPrimaryState::Coding1, HmmIntronState::None),
-            HmmState::Coding1IntronU2GtAgDSS => (HmmPrimaryState::Coding1, HmmIntronState::U2GtAgDSS),
+            HmmState::Coding1IntronU2GtAgDSS => {
+                (HmmPrimaryState::Coding1, HmmIntronState::U2GtAgDSS)
+            }
             HmmState::Coding1IntronU2GtAg => (HmmPrimaryState::Coding1, HmmIntronState::U2GtAg),
-            HmmState::Coding1IntronU2GcAgDSS => (HmmPrimaryState::Coding1, HmmIntronState::U2GcAgDSS),
+            HmmState::Coding1IntronU2GcAgDSS => {
+                (HmmPrimaryState::Coding1, HmmIntronState::U2GcAgDSS)
+            }
             HmmState::Coding1IntronU2GcAg => (HmmPrimaryState::Coding1, HmmIntronState::U2GcAg),
-            HmmState::Coding1IntronU12AtAcDSS => (HmmPrimaryState::Coding1, HmmIntronState::U12AtAcDSS),
+            HmmState::Coding1IntronU12AtAcDSS => {
+                (HmmPrimaryState::Coding1, HmmIntronState::U12AtAcDSS)
+            }
             HmmState::Coding1IntronU12AtAc => (HmmPrimaryState::Coding1, HmmIntronState::U12AtAc),
 
             HmmState::Coding2 => (HmmPrimaryState::Coding2, HmmIntronState::None),
-            HmmState::Coding2IntronU2GtAgDSS => (HmmPrimaryState::Coding2, HmmIntronState::U2GtAgDSS),
+            HmmState::Coding2IntronU2GtAgDSS => {
+                (HmmPrimaryState::Coding2, HmmIntronState::U2GtAgDSS)
+            }
             HmmState::Coding2IntronU2GtAg => (HmmPrimaryState::Coding2, HmmIntronState::U2GtAg),
-            HmmState::Coding2IntronU2GcAgDSS => (HmmPrimaryState::Coding2, HmmIntronState::U2GcAgDSS),
+            HmmState::Coding2IntronU2GcAgDSS => {
+                (HmmPrimaryState::Coding2, HmmIntronState::U2GcAgDSS)
+            }
             HmmState::Coding2IntronU2GcAg => (HmmPrimaryState::Coding2, HmmIntronState::U2GcAg),
-            HmmState::Coding2IntronU12AtAcDSS => (HmmPrimaryState::Coding2, HmmIntronState::U12AtAcDSS),
+            HmmState::Coding2IntronU12AtAcDSS => {
+                (HmmPrimaryState::Coding2, HmmIntronState::U12AtAcDSS)
+            }
             HmmState::Coding2IntronU12AtAc => (HmmPrimaryState::Coding2, HmmIntronState::U12AtAc),
 
             HmmState::Stop0T => (HmmPrimaryState::Stop0T, HmmIntronState::None),
@@ -745,23 +790,37 @@ impl HmmState
             HmmState::Stop0TIntronU2GtAg => (HmmPrimaryState::Stop0T, HmmIntronState::U2GtAg),
             HmmState::Stop0TIntronU2GcAgDSS => (HmmPrimaryState::Stop0T, HmmIntronState::U2GcAgDSS),
             HmmState::Stop0TIntronU2GcAg => (HmmPrimaryState::Stop0T, HmmIntronState::U2GcAg),
-            HmmState::Stop0TIntronU12AtAcDSS => (HmmPrimaryState::Stop0T, HmmIntronState::U12AtAcDSS),
+            HmmState::Stop0TIntronU12AtAcDSS => {
+                (HmmPrimaryState::Stop0T, HmmIntronState::U12AtAcDSS)
+            }
             HmmState::Stop0TIntronU12AtAc => (HmmPrimaryState::Stop0T, HmmIntronState::U12AtAc),
 
             HmmState::Stop1TA => (HmmPrimaryState::Stop1TA, HmmIntronState::None),
-            HmmState::Stop1TAIntronU2GtAgDSS => (HmmPrimaryState::Stop1TA, HmmIntronState::U2GtAgDSS),
+            HmmState::Stop1TAIntronU2GtAgDSS => {
+                (HmmPrimaryState::Stop1TA, HmmIntronState::U2GtAgDSS)
+            }
             HmmState::Stop1TAIntronU2GtAg => (HmmPrimaryState::Stop1TA, HmmIntronState::U2GtAg),
-            HmmState::Stop1TAIntronU2GcAgDSS => (HmmPrimaryState::Stop1TA, HmmIntronState::U2GcAgDSS),
+            HmmState::Stop1TAIntronU2GcAgDSS => {
+                (HmmPrimaryState::Stop1TA, HmmIntronState::U2GcAgDSS)
+            }
             HmmState::Stop1TAIntronU2GcAg => (HmmPrimaryState::Stop1TA, HmmIntronState::U2GcAg),
-            HmmState::Stop1TAIntronU12AtAcDSS => (HmmPrimaryState::Stop1TA, HmmIntronState::U12AtAcDSS),
+            HmmState::Stop1TAIntronU12AtAcDSS => {
+                (HmmPrimaryState::Stop1TA, HmmIntronState::U12AtAcDSS)
+            }
             HmmState::Stop1TAIntronU12AtAc => (HmmPrimaryState::Stop1TA, HmmIntronState::U12AtAc),
 
             HmmState::Stop1TG => (HmmPrimaryState::Stop1TG, HmmIntronState::None),
-            HmmState::Stop1TGIntronU2GtAgDSS => (HmmPrimaryState::Stop1TG, HmmIntronState::U2GtAgDSS),
+            HmmState::Stop1TGIntronU2GtAgDSS => {
+                (HmmPrimaryState::Stop1TG, HmmIntronState::U2GtAgDSS)
+            }
             HmmState::Stop1TGIntronU2GtAg => (HmmPrimaryState::Stop1TG, HmmIntronState::U2GtAg),
-            HmmState::Stop1TGIntronU2GcAgDSS => (HmmPrimaryState::Stop1TG, HmmIntronState::U2GcAgDSS),
+            HmmState::Stop1TGIntronU2GcAgDSS => {
+                (HmmPrimaryState::Stop1TG, HmmIntronState::U2GcAgDSS)
+            }
             HmmState::Stop1TGIntronU2GcAg => (HmmPrimaryState::Stop1TG, HmmIntronState::U2GcAg),
-            HmmState::Stop1TGIntronU12AtAcDSS => (HmmPrimaryState::Stop1TG, HmmIntronState::U12AtAcDSS),
+            HmmState::Stop1TGIntronU12AtAcDSS => {
+                (HmmPrimaryState::Stop1TG, HmmIntronState::U12AtAcDSS)
+            }
             HmmState::Stop1TGIntronU12AtAc => (HmmPrimaryState::Stop1TG, HmmIntronState::U12AtAc),
 
             HmmState::Stop2 => (HmmPrimaryState::Stop2, HmmIntronState::None),
@@ -776,456 +835,785 @@ impl HmmState
         }
     }
 
-
-    fn get_annotation_label(self) -> HmmAnnotationLabel
-    {
+    fn get_annotation_label(self) -> HmmAnnotationLabel {
         let (primary, intron) = self.get_component_states();
 
-        if intron!=HmmIntronState::None
-            { return HmmAnnotationLabel::Intron; }
+        if intron != HmmIntronState::None {
+            return HmmAnnotationLabel::Intron;
+        }
 
-        match primary
-            {
+        match primary {
             HmmPrimaryState::Intergenic => HmmAnnotationLabel::Intergenic,
 
             HmmPrimaryState::UTR5 => HmmAnnotationLabel::UTR5,
 
-            HmmPrimaryState::Start0 |
-            HmmPrimaryState::Start1 |
-            HmmPrimaryState::Start2 => HmmAnnotationLabel::Coding, //Start,
+            HmmPrimaryState::Start0 | HmmPrimaryState::Start1 | HmmPrimaryState::Start2 => {
+                HmmAnnotationLabel::Coding
+            } //Start,
 
-            HmmPrimaryState::Coding0 |
-            HmmPrimaryState::Coding1 |
-            HmmPrimaryState::Coding2 => HmmAnnotationLabel::Coding,
-
-            HmmPrimaryState::Stop0T |
-            HmmPrimaryState::Stop1TA |
-            HmmPrimaryState::Stop1TG |
-            HmmPrimaryState::Stop2 => HmmAnnotationLabel::Coding, //Stop,
-
-            HmmPrimaryState::UTR3 => HmmAnnotationLabel::UTR3
+            HmmPrimaryState::Coding0 | HmmPrimaryState::Coding1 | HmmPrimaryState::Coding2 => {
+                HmmAnnotationLabel::Coding
             }
-    }
 
-    #[allow(unused_variables)]
-    fn get_state_penalty(self, class_pred: &ClassPredPenalty, phase_pred: &PhasePredPenalty, pred: &PredPenalty) -> f64
-    {
-        let (primary, intron) = self.get_component_states();
+            HmmPrimaryState::Stop0T
+            | HmmPrimaryState::Stop1TA
+            | HmmPrimaryState::Stop1TG
+            | HmmPrimaryState::Stop2 => HmmAnnotationLabel::Coding, //Stop,
 
-        if intron!=HmmIntronState::None
-            { return class_pred.get_intron_penalty(); }
-
-        match primary
-        {
-            HmmPrimaryState::Intergenic => class_pred.get_intergenic_penalty(),
-
-            HmmPrimaryState::UTR5 |
-            HmmPrimaryState::UTR3 => class_pred.get_utr_penalty(),
-
-            HmmPrimaryState::Coding0 =>
-                //class_pred.get_coding_penalty(),
-                //class_pred.get_coding_penalty() + phase_pred.get_phase0_penalty(),
-                pred.get_coding_phase0_penalty(),
-
-            HmmPrimaryState::Start0 |
-            HmmPrimaryState::Stop0T =>
-                //class_pred.get_coding_penalty(),
-                //class_pred.get_coding_penalty() + phase_pred.get_phase0_penalty(),
-                pred.get_coding_phase0_penalty(),
-
-            HmmPrimaryState::Coding1 =>
-                //class_pred.get_coding_penalty(),
-                //class_pred.get_coding_penalty() + phase_pred.get_phase2_penalty(),
-                pred.get_coding_phase2_penalty(),
-
-            HmmPrimaryState::Start1 |
-            HmmPrimaryState::Stop1TA |
-            HmmPrimaryState::Stop1TG =>
-                //class_pred.get_coding_penalty(),
-                //class_pred.get_coding_penalty() + phase_pred.get_phase2_penalty(),
-                pred.get_coding_phase2_penalty(),
-
-            HmmPrimaryState::Coding2 =>
-                //class_pred.get_coding_penalty(),
-                //class_pred.get_coding_penalty() + phase_pred.get_phase1_penalty(),
-                pred.get_coding_phase1_penalty(),
-
-            HmmPrimaryState::Start2 |
-            HmmPrimaryState::Stop2 =>
-                //class_pred.get_coding_penalty(),
-                //class_pred.get_coding_penalty() + phase_pred.get_phase1_penalty(),
-                pred.get_coding_phase1_penalty(),
+            HmmPrimaryState::UTR3 => HmmAnnotationLabel::UTR3,
         }
     }
 
-    fn get_base_count(self) -> usize
-    {
+    #[allow(unused_variables)]
+    fn get_state_penalty(
+        self,
+        class_pred: &ClassPredPenalty,
+        phase_pred: &PhasePredPenalty,
+        pred: &PredPenalty,
+    ) -> f64 {
+        let (primary, intron) = self.get_component_states();
+
+        if intron != HmmIntronState::None {
+            return class_pred.get_intron_penalty();
+        }
+
+        match primary {
+            HmmPrimaryState::Intergenic => class_pred.get_intergenic_penalty(),
+
+            HmmPrimaryState::UTR5 | HmmPrimaryState::UTR3 => class_pred.get_utr_penalty(),
+
+            HmmPrimaryState::Coding0 =>
+            //class_pred.get_coding_penalty(),
+            //class_pred.get_coding_penalty() + phase_pred.get_phase0_penalty(),
+            {
+                pred.get_coding_phase0_penalty()
+            }
+
+            HmmPrimaryState::Start0 | HmmPrimaryState::Stop0T =>
+            //class_pred.get_coding_penalty(),
+            //class_pred.get_coding_penalty() + phase_pred.get_phase0_penalty(),
+            {
+                pred.get_coding_phase0_penalty()
+            }
+
+            HmmPrimaryState::Coding1 =>
+            //class_pred.get_coding_penalty(),
+            //class_pred.get_coding_penalty() + phase_pred.get_phase2_penalty(),
+            {
+                pred.get_coding_phase2_penalty()
+            }
+
+            HmmPrimaryState::Start1 | HmmPrimaryState::Stop1TA | HmmPrimaryState::Stop1TG =>
+            //class_pred.get_coding_penalty(),
+            //class_pred.get_coding_penalty() + phase_pred.get_phase2_penalty(),
+            {
+                pred.get_coding_phase2_penalty()
+            }
+
+            HmmPrimaryState::Coding2 =>
+            //class_pred.get_coding_penalty(),
+            //class_pred.get_coding_penalty() + phase_pred.get_phase1_penalty(),
+            {
+                pred.get_coding_phase1_penalty()
+            }
+
+            HmmPrimaryState::Start2 | HmmPrimaryState::Stop2 =>
+            //class_pred.get_coding_penalty(),
+            //class_pred.get_coding_penalty() + phase_pred.get_phase1_penalty(),
+            {
+                pred.get_coding_phase1_penalty()
+            }
+        }
+    }
+
+    fn get_base_count(self) -> usize {
         let (_, intron) = self.get_component_states();
 
-        match intron
-        {
+        match intron {
             HmmIntronState::U2GtAgDSS => 49,
             HmmIntronState::U2GcAgDSS => 49,
             HmmIntronState::U12AtAcDSS => 29,
-            _ => 1
+            _ => 1,
         }
     }
 
     // Calculate the common (minimum) penalty for each 'destination' state - based on either DSS (intron start) or primary states with base matches (start/stop)
     // Valid for Intron DSS and all non-intron states
-    fn get_common_state_entrance_penalty(self: HmmState, trans_ctx: &TransitionContext) -> Option<f64>
-    {
+    fn get_common_state_entrance_penalty(
+        self: HmmState,
+        trans_ctx: &TransitionContext,
+    ) -> Option<f64> {
         let (primary, intron) = self.get_component_states();
 
-        if intron!=HmmIntronState::None
-            {
-            match intron
-                {
+        if intron != HmmIntronState::None {
+            match intron {
                 HmmIntronState::U2GtAgDSS => return trans_ctx.get_donor_penalty_u2_gt_ag(true),
                 HmmIntronState::U2GcAgDSS => return trans_ctx.get_donor_penalty_u2_gc_ag(true),
                 HmmIntronState::U12AtAcDSS => return trans_ctx.get_donor_penalty_u12_at_ac(true),
 
-                _ => panic!("Called get_state_entrance_penalty with unexpected state {} - {} {}", self as u8, primary.to_str(), intron.to_str())
-                }
+                _ => panic!(
+                    "Called get_state_entrance_penalty with unexpected state {} - {} {}",
+                    self as u8,
+                    primary.to_str(),
+                    intron.to_str()
+                ),
             }
+        }
 
-        match primary
-        {
+        match primary {
             HmmPrimaryState::Intergenic => Some(0.0),
 
             HmmPrimaryState::UTR5 => Some(0.0),
 
-            HmmPrimaryState::Start0 => trans_ctx.get_downstream(1).map(|ds| ds[0].get_a()*START_WEIGHT),
-            HmmPrimaryState::Start1 => trans_ctx.get_downstream(1).map(|ds| ds[0].get_t()*START_WEIGHT),
-            HmmPrimaryState::Start2 => trans_ctx.get_downstream(1).map(|ds| ds[0].get_g()*START_WEIGHT),
+            HmmPrimaryState::Start0 => trans_ctx
+                .get_downstream(1)
+                .map(|ds| ds[0].get_a() * START_WEIGHT),
+            HmmPrimaryState::Start1 => trans_ctx
+                .get_downstream(1)
+                .map(|ds| ds[0].get_t() * START_WEIGHT),
+            HmmPrimaryState::Start2 => trans_ctx
+                .get_downstream(1)
+                .map(|ds| ds[0].get_g() * START_WEIGHT),
 
-            HmmPrimaryState::Coding0 => trans_ctx.get_downstream(1).map(|ds| min3(ds[0].get_a(),ds[0].get_c(),ds[0].get_g())*STOP_WEIGHT),
+            HmmPrimaryState::Coding0 => trans_ctx
+                .get_downstream(1)
+                .map(|ds| min3(ds[0].get_a(), ds[0].get_c(), ds[0].get_g()) * STOP_WEIGHT),
             HmmPrimaryState::Coding1 => Some(0.0),
             HmmPrimaryState::Coding2 => Some(0.0),
 
-            HmmPrimaryState::Stop0T => trans_ctx.get_downstream(1).map(|ds| ds[0].get_t()*STOP_WEIGHT),
-            HmmPrimaryState::Stop1TA => trans_ctx.get_downstream(1).map(|ds| ds[0].get_a()*STOP_WEIGHT),
-            HmmPrimaryState::Stop1TG => trans_ctx.get_downstream(1).map(|ds| ds[0].get_g()*STOP_WEIGHT),
+            HmmPrimaryState::Stop0T => trans_ctx
+                .get_downstream(1)
+                .map(|ds| ds[0].get_t() * STOP_WEIGHT),
+            HmmPrimaryState::Stop1TA => trans_ctx
+                .get_downstream(1)
+                .map(|ds| ds[0].get_a() * STOP_WEIGHT),
+            HmmPrimaryState::Stop1TG => trans_ctx
+                .get_downstream(1)
+                .map(|ds| ds[0].get_g() * STOP_WEIGHT),
             HmmPrimaryState::Stop2 => Some(0.0),
 
             HmmPrimaryState::UTR3 => Some(0.0),
         }
     }
 
-
-
-    fn populate_successor_states_and_transition_penalties(self, trans_ctx: &TransitionContext, successors: &mut Vec<(HmmState, f64)>)
-    {
-        let consider_transition = |successors: &mut Vec<(HmmState, f64)>, new_state: HmmState, other_pen: Option<f64>, allow: bool |
-            {
-                if let (true, Some(ex), Some(en)) = (allow, other_pen, new_state.get_common_state_entrance_penalty(trans_ctx))
-                { successors.push((new_state, ex+en));  }
-            };
+    fn populate_successor_states_and_transition_penalties(
+        self,
+        trans_ctx: &TransitionContext,
+        successors: &mut Vec<(HmmState, f64)>,
+    ) {
+        let consider_transition = |successors: &mut Vec<(HmmState, f64)>,
+                                   new_state: HmmState,
+                                   other_pen: Option<f64>,
+                                   allow: bool| {
+            if let (true, Some(ex), Some(en)) = (
+                allow,
+                other_pen,
+                new_state.get_common_state_entrance_penalty(trans_ctx),
+            ) {
+                successors.push((new_state, ex + en));
+            }
+        };
 
         let (_, intron) = self.get_component_states();
 
-        let acceptor_penalty = match intron
-            {
-                HmmIntronState::None => Some(0.0),
-                HmmIntronState::U2GtAg => trans_ctx.get_acceptor_penalty_u2_gt_ag(),
-                HmmIntronState::U2GcAg => trans_ctx.get_acceptor_penalty_u2_gc_ag(),
-                HmmIntronState::U12AtAc => trans_ctx.get_acceptor_penalty_u12_at_ac(),
-                _ => None,
-            };
+        let acceptor_penalty = match intron {
+            HmmIntronState::None => Some(0.0),
+            HmmIntronState::U2GtAg => trans_ctx.get_acceptor_penalty_u2_gt_ag(),
+            HmmIntronState::U2GcAg => trans_ctx.get_acceptor_penalty_u2_gc_ag(),
+            HmmIntronState::U12AtAc => trans_ctx.get_acceptor_penalty_u12_at_ac(),
+            _ => None,
+        };
 
-        match self
-            {
-            HmmState::Intergenic =>
-                    {
-                    successors.push((self, 0.0));
-                    consider_transition(successors, HmmState::UTR5, Some(0.0), true);
-                    },
-
-            HmmState::UTR5 =>
-                    {
-                    successors.push((self, 0.0));
-                    consider_transition(successors, HmmState::Start0, Some(0.0), true);
-                    consider_transition(successors, HmmState::UTR5IntronU2GtAgDSS, Some(0.0), CAN_SPLICE_UTR5);
-                    consider_transition(successors, HmmState::UTR5IntronU2GcAgDSS, Some(0.0), CAN_SPLICE_UTR5);
-                    consider_transition(successors, HmmState::UTR5IntronU12AtAcDSS, Some(0.0), CAN_SPLICE_UTR5);
-                    },
-
-            HmmState::UTR5IntronU2GtAgDSS => { successors.push((HmmState::UTR5IntronU2GtAg, 0.0))},
-            HmmState::UTR5IntronU2GcAgDSS => { successors.push((HmmState::UTR5IntronU2GcAg, 0.0))},
-            HmmState::UTR5IntronU12AtAcDSS => { successors.push((HmmState::UTR5IntronU12AtAc, 0.0))},
-
-            HmmState::UTR5IntronU2GtAg |
-            HmmState::UTR5IntronU2GcAg |
-            HmmState::UTR5IntronU12AtAc =>
-                    {
-                    successors.push((self, 0.0));
-                    consider_transition(successors, HmmState::UTR5, acceptor_penalty, CAN_SPLICE_UTR5);
-                    consider_transition(successors, HmmState::Start0, acceptor_penalty, CAN_SPLICE_UTR5_START);
-                    },
-
-            HmmState::Start0 =>
-                    {
-                    consider_transition(successors, HmmState::Start1, Some(0.0), true);
-                    consider_transition(successors, HmmState::Start0IntronU2GtAgDSS, Some(0.0), CAN_SPLICE_START);
-                    consider_transition(successors, HmmState::Start0IntronU2GcAgDSS, Some(0.0), CAN_SPLICE_START);
-                    consider_transition(successors, HmmState::Start0IntronU12AtAcDSS, Some(0.0), CAN_SPLICE_START);
-                    },
-
-            HmmState::Start0IntronU2GtAgDSS => { successors.push((HmmState::Start0IntronU2GtAg, 0.0))},
-            HmmState::Start0IntronU2GcAgDSS => { successors.push((HmmState::Start0IntronU2GcAg, 0.0))},
-            HmmState::Start0IntronU12AtAcDSS => { successors.push((HmmState::Start0IntronU12AtAc, 0.0))},
-
-            HmmState::Start0IntronU2GtAg |
-            HmmState::Start0IntronU2GcAg |
-            HmmState::Start0IntronU12AtAc =>
-                    {
-                    successors.push((self, 0.0));
-                    consider_transition(successors, HmmState::Start1, acceptor_penalty, CAN_SPLICE_START);
-                    },
-
-            HmmState::Start1 =>
-                    {
-                    consider_transition(successors, HmmState::Start2, Some(0.0), true);
-                    consider_transition(successors, HmmState::Start1IntronU2GtAgDSS, Some(0.0), CAN_SPLICE_START);
-                    consider_transition(successors, HmmState::Start1IntronU2GcAgDSS, Some(0.0), CAN_SPLICE_START);
-                    consider_transition(successors, HmmState::Start1IntronU12AtAcDSS, Some(0.0), CAN_SPLICE_START);
-                    },
-
-            HmmState::Start1IntronU2GtAgDSS => { successors.push((HmmState::Start1IntronU2GtAg, 0.0))},
-            HmmState::Start1IntronU2GcAgDSS => { successors.push((HmmState::Start1IntronU2GcAg, 0.0))},
-            HmmState::Start1IntronU12AtAcDSS => { successors.push((HmmState::Start1IntronU12AtAc, 0.0))},
-
-            HmmState::Start1IntronU2GtAg |
-            HmmState::Start1IntronU2GcAg |
-            HmmState::Start1IntronU12AtAc =>
-                    {
-                    successors.push((self, 0.0));
-                    consider_transition(successors, HmmState::Start2, acceptor_penalty, CAN_SPLICE_START);
-                    },
-
-             HmmState::Coding0 =>
-                    {
-                    consider_transition(successors, HmmState::Coding1, Some(0.0), true);
-
-                    consider_transition(successors, HmmState::Coding0IntronU2GtAgDSS, Some(0.0), CAN_SPLICE_CODING);
-                    consider_transition(successors, HmmState::Coding0IntronU2GcAgDSS, Some(0.0), CAN_SPLICE_CODING);
-                    consider_transition(successors, HmmState::Coding0IntronU12AtAcDSS, Some(0.0), CAN_SPLICE_CODING);
-                    }
-
-            HmmState::Coding0IntronU2GtAgDSS => { successors.push((HmmState::Coding0IntronU2GtAg, 0.0))},
-            HmmState::Coding0IntronU2GcAgDSS => { successors.push((HmmState::Coding0IntronU2GcAg, 0.0))},
-            HmmState::Coding0IntronU12AtAcDSS => { successors.push((HmmState::Coding0IntronU12AtAc, 0.0))},
-
-            HmmState::Coding0IntronU2GtAg |
-            HmmState::Coding0IntronU2GcAg |
-            HmmState::Coding0IntronU12AtAc =>
-                    {
-                    successors.push((self, 0.0));
-                    consider_transition(successors, HmmState::Coding1, acceptor_penalty, CAN_SPLICE_CODING);
-                    },
-
-            HmmState::Coding1 =>
-                    {
-                    consider_transition(successors, HmmState::Coding2, Some(0.0), true);
-
-                    consider_transition(successors, HmmState::Coding1IntronU2GtAgDSS, Some(0.0), CAN_SPLICE_CODING);
-                    consider_transition(successors, HmmState::Coding1IntronU2GcAgDSS, Some(0.0), CAN_SPLICE_CODING);
-                    consider_transition(successors, HmmState::Coding1IntronU12AtAcDSS, Some(0.0), CAN_SPLICE_CODING);
-                    }
-
-            HmmState::Coding1IntronU2GtAgDSS => { successors.push((HmmState::Coding1IntronU2GtAg, 0.0))},
-            HmmState::Coding1IntronU2GcAgDSS => { successors.push((HmmState::Coding1IntronU2GcAg, 0.0))},
-            HmmState::Coding1IntronU12AtAcDSS => { successors.push((HmmState::Coding1IntronU12AtAc, 0.0))},
-
-            HmmState::Coding1IntronU2GtAg |
-            HmmState::Coding1IntronU2GcAg |
-            HmmState::Coding1IntronU12AtAc =>
-                    {
-                    successors.push((self, 0.0));
-                    consider_transition(successors, HmmState::Coding2, acceptor_penalty, CAN_SPLICE_CODING);
-                    },
-
-            HmmState::Start2 |
-            HmmState::Coding2 =>
-                    {
-                    consider_transition(successors, HmmState::Coding0, Some(0.0), true);
-                    consider_transition(successors, HmmState::Stop0T, Some(0.0), true);
-
-                    consider_transition(successors, HmmState::Coding2IntronU2GtAgDSS, Some(0.0), CAN_SPLICE_CODING);
-                    consider_transition(successors, HmmState::Coding2IntronU2GcAgDSS, Some(0.0), CAN_SPLICE_CODING);
-                    consider_transition(successors, HmmState::Coding2IntronU12AtAcDSS, Some(0.0), CAN_SPLICE_CODING);
-                    }
-
-            HmmState::Coding2IntronU2GtAgDSS => { successors.push((HmmState::Coding2IntronU2GtAg, 0.0))},
-            HmmState::Coding2IntronU2GcAgDSS => { successors.push((HmmState::Coding2IntronU2GcAg, 0.0))},
-            HmmState::Coding2IntronU12AtAcDSS => { successors.push((HmmState::Coding2IntronU12AtAc, 0.0))},
-
-            HmmState::Coding2IntronU2GtAg |
-            HmmState::Coding2IntronU2GcAg |
-            HmmState::Coding2IntronU12AtAc =>
-                    {
-                    successors.push((self, 0.0));
-                    consider_transition(successors, HmmState::Coding0, acceptor_penalty, CAN_SPLICE_CODING);
-                    consider_transition(successors, HmmState::Stop0T, acceptor_penalty, CAN_SPLICE_CODING_STOP);
-                    },
-
-            HmmState::Stop0T =>  // Equivalent to Coding0, but potentially a stop codon (Txx)
-                    {
-                    consider_transition(successors, HmmState::Stop1TA, Some(0.0), true);
-                    consider_transition(successors, HmmState::Stop1TG, Some(0.0), true);
-
-                    if let Some(ds) = trans_ctx.get_downstream(1)
-                        { consider_transition(successors, HmmState::Coding1, Some(min2(ds[0].get_c(), ds[0].get_t())*STOP_WEIGHT), true); }
-
-                    consider_transition(successors, HmmState::Stop0TIntronU2GtAgDSS, Some(0.0), CAN_SPLICE_STOP);
-                    consider_transition(successors, HmmState::Stop0TIntronU2GcAgDSS, Some(0.0), CAN_SPLICE_STOP);
-                    consider_transition(successors, HmmState::Stop0TIntronU12AtAcDSS, Some(0.0), CAN_SPLICE_STOP);
-                    },
-
-            HmmState::Stop0TIntronU2GtAgDSS => { successors.push((HmmState::Stop0TIntronU2GtAg, 0.0))},
-            HmmState::Stop0TIntronU2GcAgDSS => { successors.push((HmmState::Stop0TIntronU2GcAg, 0.0))},
-            HmmState::Stop0TIntronU12AtAcDSS => { successors.push((HmmState::Stop0TIntronU12AtAc, 0.0))},
-
-            HmmState::Stop0TIntronU2GtAg |
-            HmmState::Stop0TIntronU2GcAg |
-            HmmState::Stop0TIntronU12AtAc =>
-                    {
-                    successors.push((self, 0.0));
-                    consider_transition(successors, HmmState::Stop1TA, acceptor_penalty, true);
-                    consider_transition(successors, HmmState::Stop1TG, acceptor_penalty, true);
-
-                    if let (Some(acceptor_penalty), Some(ds)) = (acceptor_penalty, trans_ctx.get_downstream(1))
-                        { consider_transition(successors, HmmState::Coding1, Some(acceptor_penalty + min2(ds[0].get_c(), ds[0].get_t())*STOP_WEIGHT), CAN_SPLICE_STOP); }
-                    }
-
-            HmmState::Stop1TA =>  // Equivalent to Coding1, but potentially a stop codon (TAx)
-                    {
-                    if let Some(ds) = trans_ctx.get_downstream(1)
-                        {
-                        consider_transition(successors, HmmState::Stop2, Some(min2(ds[0].get_a(), ds[0].get_g())*STOP_WEIGHT), true);
-                        consider_transition(successors, HmmState::Coding2, Some(min2(ds[0].get_c(), ds[0].get_t())*STOP_WEIGHT), true);
-                        }
-
-                    consider_transition(successors, HmmState::Stop1TAIntronU2GtAgDSS, Some(0.0), CAN_SPLICE_STOP);
-                    consider_transition(successors, HmmState::Stop1TAIntronU2GcAgDSS, Some(0.0), CAN_SPLICE_STOP);
-                    consider_transition(successors, HmmState::Stop1TAIntronU12AtAcDSS, Some(0.0), CAN_SPLICE_STOP);
-                    },
-
-            HmmState::Stop1TAIntronU2GtAgDSS => { successors.push((HmmState::Stop1TAIntronU2GtAg, 0.0))},
-            HmmState::Stop1TAIntronU2GcAgDSS => { successors.push((HmmState::Stop1TAIntronU2GcAg, 0.0))},
-            HmmState::Stop1TAIntronU12AtAcDSS => { successors.push((HmmState::Stop1TAIntronU12AtAc, 0.0))},
-
-            HmmState::Stop1TAIntronU2GtAg |
-            HmmState::Stop1TAIntronU2GcAg |
-            HmmState::Stop1TAIntronU12AtAc =>
-                    {
-                    successors.push((self, 0.0));
-
-                    if let (Some(acceptor_penalty), Some(ds)) = (acceptor_penalty, trans_ctx.get_downstream(1))
-                        {
-                        consider_transition(successors, HmmState::Stop2, Some(acceptor_penalty + min2(ds[0].get_a(), ds[0].get_g())*STOP_WEIGHT), true);
-                        consider_transition(successors, HmmState::Coding2, Some(acceptor_penalty + min2(ds[0].get_c(), ds[0].get_t())*STOP_WEIGHT), true);
-                        }
-                    }
-
-            HmmState::Stop1TG => // Equivalent to Coding1, but potentially a stop codon (TGx)
-                    {
-                    if let Some(ds) = trans_ctx.get_downstream(1)
-                        {
-                        consider_transition(successors, HmmState::Stop2, Some(ds[0].get_a()*STOP_WEIGHT), true);
-                        consider_transition(successors, HmmState::Coding2, Some(min3(ds[0].get_c(), ds[0].get_g(),ds[0].get_t())*STOP_WEIGHT), true);
-                        }
-
-                    consider_transition(successors, HmmState::Stop1TGIntronU2GtAgDSS, Some(0.0), CAN_SPLICE_STOP);
-                    consider_transition(successors, HmmState::Stop1TGIntronU2GcAgDSS, Some(0.0), CAN_SPLICE_STOP);
-                    consider_transition(successors, HmmState::Stop1TGIntronU12AtAcDSS, Some(0.0), CAN_SPLICE_STOP);
-                    },
-
-            HmmState::Stop1TGIntronU2GtAgDSS => { successors.push((HmmState::Stop1TGIntronU2GtAg, 0.0))},
-            HmmState::Stop1TGIntronU2GcAgDSS => { successors.push((HmmState::Stop1TGIntronU2GcAg, 0.0))},
-            HmmState::Stop1TGIntronU12AtAcDSS => { successors.push((HmmState::Stop1TGIntronU12AtAc, 0.0))},
-
-            HmmState::Stop1TGIntronU2GtAg |
-            HmmState::Stop1TGIntronU2GcAg |
-            HmmState::Stop1TGIntronU12AtAc =>
-                    {
-                    successors.push((self, 0.0));
-
-                    if let (Some(acceptor_penalty), Some(ds)) = (acceptor_penalty, trans_ctx.get_downstream(1))
-                        {
-                        consider_transition(successors, HmmState::Stop2, Some(acceptor_penalty + ds[0].get_a()*STOP_WEIGHT), true);
-                        consider_transition(successors, HmmState::Coding2, Some(acceptor_penalty + min3(ds[0].get_c(), ds[0].get_g(),ds[0].get_t())*STOP_WEIGHT), true);
-                        }
-                    }
-
-            HmmState::Stop2 =>
-                    {
-                    successors.push((HmmState::UTR3, 0.0));
-                    consider_transition(successors, HmmState::UTR3IntronU2GtAgDSS, Some(0.0), CAN_SPLICE_STOP_UTR3);
-                    consider_transition(successors, HmmState::UTR3IntronU2GcAgDSS, Some(0.0), CAN_SPLICE_STOP_UTR3);
-                    consider_transition(successors, HmmState::UTR3IntronU12AtAcDSS, Some(0.0), CAN_SPLICE_STOP_UTR3);
-                    },
-
-            HmmState::UTR3 =>
-                    {
-                    successors.push((self, 0.0));
-                    successors.push((HmmState::Intergenic, 0.0));
-                    consider_transition(successors, HmmState::UTR3IntronU2GtAgDSS, Some(0.0), CAN_SPLICE_UTR3);
-                    consider_transition(successors, HmmState::UTR3IntronU2GcAgDSS, Some(0.0), CAN_SPLICE_UTR3);
-                    consider_transition(successors, HmmState::UTR3IntronU12AtAcDSS, Some(0.0), CAN_SPLICE_UTR3);
-                    },
-
-            HmmState::UTR3IntronU2GtAgDSS => { successors.push((HmmState::UTR3IntronU2GtAg, 0.0))},
-            HmmState::UTR3IntronU2GcAgDSS => { successors.push((HmmState::UTR3IntronU2GcAg, 0.0))},
-            HmmState::UTR3IntronU12AtAcDSS => { successors.push((HmmState::UTR3IntronU12AtAc, 0.0))},
-
-            HmmState::UTR3IntronU2GtAg |
-            HmmState::UTR3IntronU2GcAg |
-            HmmState::UTR3IntronU12AtAc =>
-                    {
-                    successors.push((self, 0.0));
-                    consider_transition(successors, HmmState::UTR3, acceptor_penalty, CAN_SPLICE_UTR3);
-                    },
+        match self {
+            HmmState::Intergenic => {
+                successors.push((self, 0.0));
+                consider_transition(successors, HmmState::UTR5, Some(0.0), true);
             }
+
+            HmmState::UTR5 => {
+                successors.push((self, 0.0));
+                consider_transition(successors, HmmState::Start0, Some(0.0), true);
+                consider_transition(
+                    successors,
+                    HmmState::UTR5IntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_UTR5,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::UTR5IntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_UTR5,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::UTR5IntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_UTR5,
+                );
+            }
+
+            HmmState::UTR5IntronU2GtAgDSS => successors.push((HmmState::UTR5IntronU2GtAg, 0.0)),
+            HmmState::UTR5IntronU2GcAgDSS => successors.push((HmmState::UTR5IntronU2GcAg, 0.0)),
+            HmmState::UTR5IntronU12AtAcDSS => successors.push((HmmState::UTR5IntronU12AtAc, 0.0)),
+
+            HmmState::UTR5IntronU2GtAg
+            | HmmState::UTR5IntronU2GcAg
+            | HmmState::UTR5IntronU12AtAc => {
+                successors.push((self, 0.0));
+                consider_transition(
+                    successors,
+                    HmmState::UTR5,
+                    acceptor_penalty,
+                    CAN_SPLICE_UTR5,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Start0,
+                    acceptor_penalty,
+                    CAN_SPLICE_UTR5_START,
+                );
+            }
+
+            HmmState::Start0 => {
+                consider_transition(successors, HmmState::Start1, Some(0.0), true);
+                consider_transition(
+                    successors,
+                    HmmState::Start0IntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_START,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Start0IntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_START,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Start0IntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_START,
+                );
+            }
+
+            HmmState::Start0IntronU2GtAgDSS => successors.push((HmmState::Start0IntronU2GtAg, 0.0)),
+            HmmState::Start0IntronU2GcAgDSS => successors.push((HmmState::Start0IntronU2GcAg, 0.0)),
+            HmmState::Start0IntronU12AtAcDSS => {
+                successors.push((HmmState::Start0IntronU12AtAc, 0.0))
+            }
+
+            HmmState::Start0IntronU2GtAg
+            | HmmState::Start0IntronU2GcAg
+            | HmmState::Start0IntronU12AtAc => {
+                successors.push((self, 0.0));
+                consider_transition(
+                    successors,
+                    HmmState::Start1,
+                    acceptor_penalty,
+                    CAN_SPLICE_START,
+                );
+            }
+
+            HmmState::Start1 => {
+                consider_transition(successors, HmmState::Start2, Some(0.0), true);
+                consider_transition(
+                    successors,
+                    HmmState::Start1IntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_START,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Start1IntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_START,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Start1IntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_START,
+                );
+            }
+
+            HmmState::Start1IntronU2GtAgDSS => successors.push((HmmState::Start1IntronU2GtAg, 0.0)),
+            HmmState::Start1IntronU2GcAgDSS => successors.push((HmmState::Start1IntronU2GcAg, 0.0)),
+            HmmState::Start1IntronU12AtAcDSS => {
+                successors.push((HmmState::Start1IntronU12AtAc, 0.0))
+            }
+
+            HmmState::Start1IntronU2GtAg
+            | HmmState::Start1IntronU2GcAg
+            | HmmState::Start1IntronU12AtAc => {
+                successors.push((self, 0.0));
+                consider_transition(
+                    successors,
+                    HmmState::Start2,
+                    acceptor_penalty,
+                    CAN_SPLICE_START,
+                );
+            }
+
+            HmmState::Coding0 => {
+                consider_transition(successors, HmmState::Coding1, Some(0.0), true);
+
+                consider_transition(
+                    successors,
+                    HmmState::Coding0IntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_CODING,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Coding0IntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_CODING,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Coding0IntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_CODING,
+                );
+            }
+
+            HmmState::Coding0IntronU2GtAgDSS => {
+                successors.push((HmmState::Coding0IntronU2GtAg, 0.0))
+            }
+            HmmState::Coding0IntronU2GcAgDSS => {
+                successors.push((HmmState::Coding0IntronU2GcAg, 0.0))
+            }
+            HmmState::Coding0IntronU12AtAcDSS => {
+                successors.push((HmmState::Coding0IntronU12AtAc, 0.0))
+            }
+
+            HmmState::Coding0IntronU2GtAg
+            | HmmState::Coding0IntronU2GcAg
+            | HmmState::Coding0IntronU12AtAc => {
+                successors.push((self, 0.0));
+                consider_transition(
+                    successors,
+                    HmmState::Coding1,
+                    acceptor_penalty,
+                    CAN_SPLICE_CODING,
+                );
+            }
+
+            HmmState::Coding1 => {
+                consider_transition(successors, HmmState::Coding2, Some(0.0), true);
+
+                consider_transition(
+                    successors,
+                    HmmState::Coding1IntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_CODING,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Coding1IntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_CODING,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Coding1IntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_CODING,
+                );
+            }
+
+            HmmState::Coding1IntronU2GtAgDSS => {
+                successors.push((HmmState::Coding1IntronU2GtAg, 0.0))
+            }
+            HmmState::Coding1IntronU2GcAgDSS => {
+                successors.push((HmmState::Coding1IntronU2GcAg, 0.0))
+            }
+            HmmState::Coding1IntronU12AtAcDSS => {
+                successors.push((HmmState::Coding1IntronU12AtAc, 0.0))
+            }
+
+            HmmState::Coding1IntronU2GtAg
+            | HmmState::Coding1IntronU2GcAg
+            | HmmState::Coding1IntronU12AtAc => {
+                successors.push((self, 0.0));
+                consider_transition(
+                    successors,
+                    HmmState::Coding2,
+                    acceptor_penalty,
+                    CAN_SPLICE_CODING,
+                );
+            }
+
+            HmmState::Start2 | HmmState::Coding2 => {
+                consider_transition(successors, HmmState::Coding0, Some(0.0), true);
+                consider_transition(successors, HmmState::Stop0T, Some(0.0), true);
+
+                consider_transition(
+                    successors,
+                    HmmState::Coding2IntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_CODING,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Coding2IntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_CODING,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Coding2IntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_CODING,
+                );
+            }
+
+            HmmState::Coding2IntronU2GtAgDSS => {
+                successors.push((HmmState::Coding2IntronU2GtAg, 0.0))
+            }
+            HmmState::Coding2IntronU2GcAgDSS => {
+                successors.push((HmmState::Coding2IntronU2GcAg, 0.0))
+            }
+            HmmState::Coding2IntronU12AtAcDSS => {
+                successors.push((HmmState::Coding2IntronU12AtAc, 0.0))
+            }
+
+            HmmState::Coding2IntronU2GtAg
+            | HmmState::Coding2IntronU2GcAg
+            | HmmState::Coding2IntronU12AtAc => {
+                successors.push((self, 0.0));
+                consider_transition(
+                    successors,
+                    HmmState::Coding0,
+                    acceptor_penalty,
+                    CAN_SPLICE_CODING,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Stop0T,
+                    acceptor_penalty,
+                    CAN_SPLICE_CODING_STOP,
+                );
+            }
+
+            HmmState::Stop0T =>
+            // Equivalent to Coding0, but potentially a stop codon (Txx)
+            {
+                consider_transition(successors, HmmState::Stop1TA, Some(0.0), true);
+                consider_transition(successors, HmmState::Stop1TG, Some(0.0), true);
+
+                if let Some(ds) = trans_ctx.get_downstream(1) {
+                    consider_transition(
+                        successors,
+                        HmmState::Coding1,
+                        Some(min2(ds[0].get_c(), ds[0].get_t()) * STOP_WEIGHT),
+                        true,
+                    );
+                }
+
+                consider_transition(
+                    successors,
+                    HmmState::Stop0TIntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Stop0TIntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Stop0TIntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP,
+                );
+            }
+
+            HmmState::Stop0TIntronU2GtAgDSS => successors.push((HmmState::Stop0TIntronU2GtAg, 0.0)),
+            HmmState::Stop0TIntronU2GcAgDSS => successors.push((HmmState::Stop0TIntronU2GcAg, 0.0)),
+            HmmState::Stop0TIntronU12AtAcDSS => {
+                successors.push((HmmState::Stop0TIntronU12AtAc, 0.0))
+            }
+
+            HmmState::Stop0TIntronU2GtAg
+            | HmmState::Stop0TIntronU2GcAg
+            | HmmState::Stop0TIntronU12AtAc => {
+                successors.push((self, 0.0));
+                consider_transition(successors, HmmState::Stop1TA, acceptor_penalty, true);
+                consider_transition(successors, HmmState::Stop1TG, acceptor_penalty, true);
+
+                if let (Some(acceptor_penalty), Some(ds)) =
+                    (acceptor_penalty, trans_ctx.get_downstream(1))
+                {
+                    consider_transition(
+                        successors,
+                        HmmState::Coding1,
+                        Some(acceptor_penalty + min2(ds[0].get_c(), ds[0].get_t()) * STOP_WEIGHT),
+                        CAN_SPLICE_STOP,
+                    );
+                }
+            }
+
+            HmmState::Stop1TA =>
+            // Equivalent to Coding1, but potentially a stop codon (TAx)
+            {
+                if let Some(ds) = trans_ctx.get_downstream(1) {
+                    consider_transition(
+                        successors,
+                        HmmState::Stop2,
+                        Some(min2(ds[0].get_a(), ds[0].get_g()) * STOP_WEIGHT),
+                        true,
+                    );
+                    consider_transition(
+                        successors,
+                        HmmState::Coding2,
+                        Some(min2(ds[0].get_c(), ds[0].get_t()) * STOP_WEIGHT),
+                        true,
+                    );
+                }
+
+                consider_transition(
+                    successors,
+                    HmmState::Stop1TAIntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Stop1TAIntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Stop1TAIntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP,
+                );
+            }
+
+            HmmState::Stop1TAIntronU2GtAgDSS => {
+                successors.push((HmmState::Stop1TAIntronU2GtAg, 0.0))
+            }
+            HmmState::Stop1TAIntronU2GcAgDSS => {
+                successors.push((HmmState::Stop1TAIntronU2GcAg, 0.0))
+            }
+            HmmState::Stop1TAIntronU12AtAcDSS => {
+                successors.push((HmmState::Stop1TAIntronU12AtAc, 0.0))
+            }
+
+            HmmState::Stop1TAIntronU2GtAg
+            | HmmState::Stop1TAIntronU2GcAg
+            | HmmState::Stop1TAIntronU12AtAc => {
+                successors.push((self, 0.0));
+
+                if let (Some(acceptor_penalty), Some(ds)) =
+                    (acceptor_penalty, trans_ctx.get_downstream(1))
+                {
+                    consider_transition(
+                        successors,
+                        HmmState::Stop2,
+                        Some(acceptor_penalty + min2(ds[0].get_a(), ds[0].get_g()) * STOP_WEIGHT),
+                        true,
+                    );
+                    consider_transition(
+                        successors,
+                        HmmState::Coding2,
+                        Some(acceptor_penalty + min2(ds[0].get_c(), ds[0].get_t()) * STOP_WEIGHT),
+                        true,
+                    );
+                }
+            }
+
+            HmmState::Stop1TG =>
+            // Equivalent to Coding1, but potentially a stop codon (TGx)
+            {
+                if let Some(ds) = trans_ctx.get_downstream(1) {
+                    consider_transition(
+                        successors,
+                        HmmState::Stop2,
+                        Some(ds[0].get_a() * STOP_WEIGHT),
+                        true,
+                    );
+                    consider_transition(
+                        successors,
+                        HmmState::Coding2,
+                        Some(min3(ds[0].get_c(), ds[0].get_g(), ds[0].get_t()) * STOP_WEIGHT),
+                        true,
+                    );
+                }
+
+                consider_transition(
+                    successors,
+                    HmmState::Stop1TGIntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Stop1TGIntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::Stop1TGIntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP,
+                );
+            }
+
+            HmmState::Stop1TGIntronU2GtAgDSS => {
+                successors.push((HmmState::Stop1TGIntronU2GtAg, 0.0))
+            }
+            HmmState::Stop1TGIntronU2GcAgDSS => {
+                successors.push((HmmState::Stop1TGIntronU2GcAg, 0.0))
+            }
+            HmmState::Stop1TGIntronU12AtAcDSS => {
+                successors.push((HmmState::Stop1TGIntronU12AtAc, 0.0))
+            }
+
+            HmmState::Stop1TGIntronU2GtAg
+            | HmmState::Stop1TGIntronU2GcAg
+            | HmmState::Stop1TGIntronU12AtAc => {
+                successors.push((self, 0.0));
+
+                if let (Some(acceptor_penalty), Some(ds)) =
+                    (acceptor_penalty, trans_ctx.get_downstream(1))
+                {
+                    consider_transition(
+                        successors,
+                        HmmState::Stop2,
+                        Some(acceptor_penalty + ds[0].get_a() * STOP_WEIGHT),
+                        true,
+                    );
+                    consider_transition(
+                        successors,
+                        HmmState::Coding2,
+                        Some(
+                            acceptor_penalty
+                                + min3(ds[0].get_c(), ds[0].get_g(), ds[0].get_t()) * STOP_WEIGHT,
+                        ),
+                        true,
+                    );
+                }
+            }
+
+            HmmState::Stop2 => {
+                successors.push((HmmState::UTR3, 0.0));
+                consider_transition(
+                    successors,
+                    HmmState::UTR3IntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP_UTR3,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::UTR3IntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP_UTR3,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::UTR3IntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_STOP_UTR3,
+                );
+            }
+
+            HmmState::UTR3 => {
+                successors.push((self, 0.0));
+                successors.push((HmmState::Intergenic, 0.0));
+                consider_transition(
+                    successors,
+                    HmmState::UTR3IntronU2GtAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_UTR3,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::UTR3IntronU2GcAgDSS,
+                    Some(0.0),
+                    CAN_SPLICE_UTR3,
+                );
+                consider_transition(
+                    successors,
+                    HmmState::UTR3IntronU12AtAcDSS,
+                    Some(0.0),
+                    CAN_SPLICE_UTR3,
+                );
+            }
+
+            HmmState::UTR3IntronU2GtAgDSS => successors.push((HmmState::UTR3IntronU2GtAg, 0.0)),
+            HmmState::UTR3IntronU2GcAgDSS => successors.push((HmmState::UTR3IntronU2GcAg, 0.0)),
+            HmmState::UTR3IntronU12AtAcDSS => successors.push((HmmState::UTR3IntronU12AtAc, 0.0)),
+
+            HmmState::UTR3IntronU2GtAg
+            | HmmState::UTR3IntronU2GcAg
+            | HmmState::UTR3IntronU12AtAc => {
+                successors.push((self, 0.0));
+                consider_transition(
+                    successors,
+                    HmmState::UTR3,
+                    acceptor_penalty,
+                    CAN_SPLICE_UTR3,
+                );
+            }
+        }
     }
 }
 
-
-
-
-
-const PENALTY_SCALE: f64=1_000_000.0;   // Convert to u64 to avoid FP annoyances
+const PENALTY_SCALE: f64 = 1_000_000.0; // Convert to u64 to avoid FP annoyances
 
 #[derive(Copy, Clone, PartialEq, Eq)]
-pub struct HmmEval
-{
-    start_position: usize,   // Number of bases produced before this state
-    end_position: usize, // Number of bases produced including this state
+pub struct HmmEval {
+    start_position: usize, // Number of bases produced before this state
+    end_position: usize,   // Number of bases produced including this state
     state: HmmState,
     previous_state: HmmState,
 
     penalty: u64,
 }
 
-impl HmmEval
-{
-    fn new_root() -> HmmEval
-    {
-        HmmEval { start_position: 0, end_position: 0, state: HmmState::Intergenic, previous_state: HmmState::Intergenic, penalty: 0}
+impl HmmEval {
+    fn new_root() -> HmmEval {
+        HmmEval {
+            start_position: 0,
+            end_position: 0,
+            state: HmmState::Intergenic,
+            previous_state: HmmState::Intergenic,
+            penalty: 0,
+        }
     }
 
-    fn new_successor(start_position: usize, end_position: usize, state: HmmState, previous_state: HmmState, penalty: u64) -> HmmEval
-    {
-        HmmEval { start_position, end_position, state, previous_state, penalty }
+    fn new_successor(
+        start_position: usize,
+        end_position: usize,
+        state: HmmState,
+        previous_state: HmmState,
+        penalty: u64,
+    ) -> HmmEval {
+        HmmEval {
+            start_position,
+            end_position,
+            state,
+            previous_state,
+            penalty,
+        }
     }
 }
 
 impl Ord for HmmEval {
     fn cmp(&self, other: &Self) -> Ordering {
         // Order on penalty (lowest), then position (highest)
-        other.penalty.cmp(&self.penalty).
-            then_with(|| self.end_position.cmp(&other.end_position))
-            //.then_with(|| self.state.cmp(&other.state))
+        other
+            .penalty
+            .cmp(&self.penalty)
+            .then_with(|| self.end_position.cmp(&other.end_position))
+        //.then_with(|| self.state.cmp(&other.state))
     }
 }
 
@@ -1235,13 +1623,9 @@ impl PartialOrd for HmmEval {
     }
 }
 
-
-
-
 const MAX_EVALS: u64 = 100_000_000_000;
 
-pub struct PredictionHmm
-{
+pub struct PredictionHmm {
     class_pred_pen: Vec<ClassPredPenalty>,
     phase_pred_pen: Vec<PhasePredPenalty>,
 
@@ -1253,21 +1637,15 @@ pub struct PredictionHmm
     eval_heap: BinaryHeap<HmmEval>,
 }
 
-
-
-
-impl PredictionHmm
-{
-    pub fn new(bp_vector: Vec<(Bases, ClassPrediction, PhasePrediction)>) -> PredictionHmm
-    {
+impl PredictionHmm {
+    pub fn new(bp_vector: Vec<(Bases, ClassPrediction, PhasePrediction)>) -> PredictionHmm {
         let mut class_pred_pen = Vec::with_capacity(bp_vector.len());
         let mut phase_pred_pen = Vec::with_capacity(bp_vector.len());
         let mut pred_pen = Vec::with_capacity(bp_vector.len());
 
         let mut bases_pen = Vec::with_capacity(bp_vector.len());
 
-        for (bases, class_pred, phase_pred) in bp_vector.iter()
-        {
+        for (bases, class_pred, phase_pred) in bp_vector.iter() {
             class_pred_pen.push(class_pred.into());
             phase_pred_pen.push(phase_pred.into());
             pred_pen.push((class_pred, phase_pred).into());
@@ -1275,171 +1653,188 @@ impl PredictionHmm
             bases_pen.push(bases.into());
         }
 
-        let total_states = (bp_vector.len()+1) * HMM_STATES;
+        let total_states = (bp_vector.len() + 1) * HMM_STATES;
         let best_eval = vec![None; total_states];
 
         let eval_heap = BinaryHeap::new();
-        PredictionHmm { class_pred_pen, phase_pred_pen, pred_pen, bases_pen, best_eval, eval_heap }
+        PredictionHmm {
+            class_pred_pen,
+            phase_pred_pen,
+            pred_pen,
+            bases_pen,
+            best_eval,
+            eval_heap,
+        }
     }
 
-    fn consider_eval(&mut self, eval: HmmEval)
-    {
+    fn consider_eval(&mut self, eval: HmmEval) {
         let idx = eval.end_position * HMM_STATES + (eval.state as usize);
 
         let maybe_old_eval = &self.best_eval[idx];
 
-        if let Some(old_eval) = maybe_old_eval
-            {
-            if eval.penalty >= old_eval.penalty
-                { return }
+        if let Some(old_eval) = maybe_old_eval {
+            if eval.penalty >= old_eval.penalty {
+                return;
             }
+        }
 
-        self.best_eval[idx]=Some(eval);
+        self.best_eval[idx] = Some(eval);
         self.eval_heap.push(eval);
     }
 
-    fn is_eval_current(&self, eval: &HmmEval) -> bool
-    {
+    fn is_eval_current(&self, eval: &HmmEval) -> bool {
         let idx = eval.end_position * HMM_STATES + (eval.state as usize);
         let best_eval = &self.best_eval[idx].expect("Eval from heap not in best_eval");
 
         best_eval == eval
     }
 
-    fn process_eval(&mut self, eval: &HmmEval)
-    {
-        if !self.is_eval_current(eval)
-            { return; }
+    fn process_eval(&mut self, eval: &HmmEval) {
+        if !self.is_eval_current(eval) {
+            return;
+        }
 
-        let trans_ctx = TransitionContext::new(&self.class_pred_pen, &self.phase_pred_pen, &self.pred_pen, &self.bases_pen, eval.end_position);
+        let trans_ctx = TransitionContext::new(
+            &self.class_pred_pen,
+            &self.phase_pred_pen,
+            &self.pred_pen,
+            &self.bases_pen,
+            eval.end_position,
+        );
 
         let mut successors = Vec::with_capacity(HMM_STATES);
-        eval.state.populate_successor_states_and_transition_penalties(&trans_ctx, &mut successors);
+        eval.state
+            .populate_successor_states_and_transition_penalties(&trans_ctx, &mut successors);
 
-        for (next_state, trans_penalty) in successors.into_iter()
-            {
+        for (next_state, trans_penalty) in successors.into_iter() {
             let mut extra_penalty = trans_penalty;
 
             let start_position = eval.end_position;
             let end_position = start_position + next_state.get_base_count();
 
-            if end_position <= self.class_pred_pen.len()  // Drop 'long' state picked near end
-                {
-                for pos in start_position..end_position
-                    { extra_penalty += next_state.get_state_penalty(&self.class_pred_pen[pos], &self.phase_pred_pen[pos], &self.pred_pen[pos]); }
+            if end_position <= self.class_pred_pen.len()
+            // Drop 'long' state picked near end
+            {
+                for pos in start_position..end_position {
+                    extra_penalty += next_state.get_state_penalty(
+                        &self.class_pred_pen[pos],
+                        &self.phase_pred_pen[pos],
+                        &self.pred_pen[pos],
+                    );
+                }
 
                 let penalty = eval.penalty + ((extra_penalty * PENALTY_SCALE) as u64);
 
-                let next_eval = HmmEval::new_successor(start_position, end_position, next_state, eval.state, penalty);
+                let next_eval = HmmEval::new_successor(
+                    start_position,
+                    end_position,
+                    next_state,
+                    eval.state,
+                    penalty,
+                );
 
                 self.consider_eval(next_eval);
-                }
             }
+        }
     }
 
-    pub fn solve(mut self) -> Option<PredictionHmmSolution>
-    {
+    pub fn solve(mut self) -> Option<PredictionHmmSolution> {
         let initial_eval = HmmEval::new_root();
         self.consider_eval(initial_eval);
 
         let mut evals = 0;
 
-        while evals < MAX_EVALS
-        {
-            if let Some(eval) = self.eval_heap.pop()
-                {
-                if eval.end_position == self.class_pred_pen.len()
-                    { return Some(PredictionHmmSolution::new(self, eval)); }
+        while evals < MAX_EVALS {
+            if let Some(eval) = self.eval_heap.pop() {
+                if eval.end_position == self.class_pred_pen.len() {
+                    return Some(PredictionHmmSolution::new(self, eval));
+                }
 
                 self.process_eval(&eval);
-                }
-            else
-                { break; }  // Nothing left to do
+            } else {
+                break;
+            } // Nothing left to do
 
-            evals+=1;
+            evals += 1;
         }
 
         panic!("MAX_EVALS exceeded - raise limit or window thresholds");
-//        None
+        //        None
     }
 }
 
-pub struct HmmStateRegion
-{
+pub struct HmmStateRegion {
     start_pos: usize,
     end_pos: usize,
-    annotation_label: HmmAnnotationLabel
+    annotation_label: HmmAnnotationLabel,
 }
 
-impl HmmStateRegion
-{
-    fn new(start_pos: usize, end_pos: usize, base_state: HmmAnnotationLabel) -> HmmStateRegion
-    {
-        HmmStateRegion { start_pos, end_pos, annotation_label: base_state }
+impl HmmStateRegion {
+    fn new(start_pos: usize, end_pos: usize, base_state: HmmAnnotationLabel) -> HmmStateRegion {
+        HmmStateRegion {
+            start_pos,
+            end_pos,
+            annotation_label: base_state,
+        }
     }
 
-    pub fn get_start_pos(&self) -> usize { self.start_pos }
+    pub fn get_start_pos(&self) -> usize {
+        self.start_pos
+    }
 
-    pub fn get_end_pos(&self) -> usize { self.end_pos }
+    pub fn get_end_pos(&self) -> usize {
+        self.end_pos
+    }
 
-    pub fn get_annotation_label(&self) -> HmmAnnotationLabel { self.annotation_label }
+    pub fn get_annotation_label(&self) -> HmmAnnotationLabel {
+        self.annotation_label
+    }
 
-    pub fn len(&self) -> usize { self.end_pos - self.start_pos }
+    pub fn len(&self) -> usize {
+        self.end_pos - self.start_pos
+    }
 
-
-    pub fn split_genes(regions: Vec<HmmStateRegion>) -> Vec<(Vec<HmmStateRegion>, usize)>
-    {
+    pub fn split_genes(regions: Vec<HmmStateRegion>) -> Vec<(Vec<HmmStateRegion>, usize)> {
         let mut vec_of_vecs = Vec::new();
 
         let mut current_vec = Vec::new();
         let mut coding_length = 0;
 
-        for region in regions
-        {
-            if region.annotation_label == HmmAnnotationLabel::Intergenic
-            {
-                if current_vec.len()>0
-                {
+        for region in regions {
+            if region.annotation_label == HmmAnnotationLabel::Intergenic {
+                if current_vec.len() > 0 {
                     vec_of_vecs.push((current_vec, coding_length));
-                    current_vec=Vec::new();
+                    current_vec = Vec::new();
                     coding_length = 0;
                 }
-            }
-            else
-            {
-                if region.annotation_label == HmmAnnotationLabel::Coding
-                {  coding_length+= region.end_pos - region.start_pos; }
+            } else {
+                if region.annotation_label == HmmAnnotationLabel::Coding {
+                    coding_length += region.end_pos - region.start_pos;
+                }
 
                 current_vec.push(region);
             }
         }
 
-        if current_vec.len()>0
-        { vec_of_vecs.push((current_vec, coding_length)); }
+        if current_vec.len() > 0 {
+            vec_of_vecs.push((current_vec, coding_length));
+        }
 
         vec_of_vecs
     }
-
-
-
 }
 
-
-pub struct PredictionHmmSolution
-{
+pub struct PredictionHmmSolution {
     hmm: PredictionHmm,
-    eval: HmmEval
+    eval: HmmEval,
 }
 
-impl PredictionHmmSolution
-{
-    fn new(hmm: PredictionHmm, eval: HmmEval) -> PredictionHmmSolution
-    {
+impl PredictionHmmSolution {
+    fn new(hmm: PredictionHmm, eval: HmmEval) -> PredictionHmmSolution {
         PredictionHmmSolution { hmm, eval }
     }
 
-    pub fn trace_regions(&self) -> Vec<HmmStateRegion>
-    {
+    pub fn trace_regions(&self) -> Vec<HmmStateRegion> {
         let mut regions = Vec::new();
 
         let mut eval = &self.eval;
@@ -1449,65 +1844,71 @@ impl PredictionHmmSolution
 
         // End position is exclusive
 
-        while eval.end_position > 0
+        while eval.end_position > 0 {
+            if eval.state.get_annotation_label() != eval.previous_state.get_annotation_label()
+            // If prev state changes annotation label
             {
-            if eval.state.get_annotation_label()!=eval.previous_state.get_annotation_label() // If prev state changes annotation label
-                {
-                regions.push(HmmStateRegion::new(eval.start_position, region_end_pos, eval.state.get_annotation_label()));
+                regions.push(HmmStateRegion::new(
+                    eval.start_position,
+                    region_end_pos,
+                    eval.state.get_annotation_label(),
+                ));
                 region_end_pos = eval.start_position;
-                }
+            }
 
             let prev_position = eval.start_position;
             let idx = prev_position * HMM_STATES + (eval.previous_state as usize);
 
-
             eval = self.hmm.best_eval.get(idx).unwrap().as_ref().unwrap();
+        }
 
-            }
-
-        if region_end_pos > 1
-            { regions.push(HmmStateRegion::new(0, region_end_pos-1, eval.state.get_annotation_label())); }
+        if region_end_pos > 1 {
+            regions.push(HmmStateRegion::new(
+                0,
+                region_end_pos - 1,
+                eval.state.get_annotation_label(),
+            ));
+        }
 
         regions.reverse();
 
         regions
     }
 
-
-
-
-    pub fn dump(&self, position: usize)
-    {
-        println!("Solution Penalty: {} over {} bp starting at {}", self.eval.penalty, self.hmm.class_pred_pen.len(), position);
+    pub fn dump(&self, position: usize) {
+        println!(
+            "Solution Penalty: {} over {} bp starting at {}",
+            self.eval.penalty,
+            self.hmm.class_pred_pen.len(),
+            position
+        );
 
         let regions = self.trace_regions();
 
-        for region in regions.iter()
-            {
-//            println!("{} to {} is {}", region.start_pos+position+1, region.end_pos+position, region.state.to_str()); // Biologist coordinates
+        for region in regions.iter() {
+            //            println!("{} to {} is {}", region.start_pos+position+1, region.end_pos+position, region.state.to_str()); // Biologist coordinates
 
-            let mut seq = String::with_capacity(region.end_pos-region.start_pos);
-            for idx in region.start_pos .. region.end_pos
-                {
+            let mut seq = String::with_capacity(region.end_pos - region.start_pos);
+            for idx in region.start_pos..region.end_pos {
                 seq.push(self.hmm.bases_pen[idx].as_str());
-                }
-
-            println!("{} to {} aka {} to {} is {} - {}", region.start_pos, region.end_pos, region.start_pos+position, region.end_pos+position, region.annotation_label.to_str(), seq);
-
             }
 
-//        if position > 30000
-//            { panic!("First 30k"); }
+            println!(
+                "{} to {} aka {} to {} is {} - {}",
+                region.start_pos,
+                region.end_pos,
+                region.start_pos + position,
+                region.end_pos + position,
+                region.annotation_label.to_str(),
+                seq
+            );
+        }
+
+        //        if position > 30000
+        //            { panic!("First 30k"); }
         panic!("Show only one region");
     }
-
-
-
-
 }
-
-
-
 
 /*
 

--- a/helixer_post_bin/src/analysis/rater.rs
+++ b/helixer_post_bin/src/analysis/rater.rs
@@ -1,8 +1,6 @@
-
-use crate::analysis::hmm::{HmmStateRegion, HmmAnnotationLabel};
-use crate::results::conv::{ClassReference, PhaseReference, ClassPrediction, PhasePrediction};
 use crate::analysis::extractor::ComparisonIterator;
-
+use crate::analysis::hmm::{HmmAnnotationLabel, HmmStateRegion};
+use crate::results::conv::{ClassPrediction, ClassReference, PhasePrediction, PhaseReference};
 
 /*
     Rows are based on 'reference', Columns are based on 'prediction'
@@ -15,107 +13,93 @@ use crate::analysis::extractor::ComparisonIterator;
     F1 = (2 * TP) / (2 * TP + FP + FN)
 */
 
-fn calc_precision_recall_f1(true_pos: u64, false_pos: u64, false_neg: u64) -> (f64, f64, f64)
-{
+fn calc_precision_recall_f1(true_pos: u64, false_pos: u64, false_neg: u64) -> (f64, f64, f64) {
     let true_pos = true_pos as f64;
     let false_pos = false_pos as f64;
     let false_neg = false_neg as f64;
 
-    let precision = true_pos / ( true_pos + false_pos );
-    let recall = true_pos / ( true_pos + false_neg );
-    let f1 = (2.0 * true_pos ) / ( 2.0 * true_pos + false_pos + false_neg );
+    let precision = true_pos / (true_pos + false_pos);
+    let recall = true_pos / (true_pos + false_neg);
+    let f1 = (2.0 * true_pos) / (2.0 * true_pos + false_pos + false_neg);
 
     (precision, recall, f1)
 }
 
 #[derive(Copy, Clone)]
-pub struct ConfusionMatrix<const N: usize>
-{
-    count: [[u64; N]; N]
+pub struct ConfusionMatrix<const N: usize> {
+    count: [[u64; N]; N],
 }
 
-
-impl<const N: usize> ConfusionMatrix<N>
-{
+impl<const N: usize> ConfusionMatrix<N> {
     //const SMALLER: usize = N - 1;
     //const BIGGER: usize = N + 1;
 
-    pub fn new() -> ConfusionMatrix<N>
-    {
+    pub fn new() -> ConfusionMatrix<N> {
         let count = [[0; N]; N];
 
         ConfusionMatrix { count }
     }
 
-    pub fn size(&self) -> usize { N }
+    pub fn size(&self) -> usize {
+        N
+    }
 
-    pub fn accumulate(&mut self, other: & Self)
-    {
-        for p in 0..N
-            {
-            for r in 0..N
-                { self.count[r][p]+=other.count[r][p]; }
+    pub fn accumulate(&mut self, other: &Self) {
+        for p in 0..N {
+            for r in 0..N {
+                self.count[r][p] += other.count[r][p];
             }
+        }
     }
 
     /*
-    fn set(&mut self, ref_idx: usize, pred_idx: usize, count: u64)
-    {
-        self.count[ref_idx][pred_idx]=count;
+        fn set(&mut self, ref_idx: usize, pred_idx: usize, count: u64)
+        {
+            self.count[ref_idx][pred_idx]=count;
+        }
+    */
+
+    pub fn increment(&mut self, ref_idx: usize, pred_idx: usize) {
+        self.count[ref_idx][pred_idx] += 1;
     }
-*/
 
-    pub fn increment(&mut self, ref_idx: usize, pred_idx: usize)
-    {
-        self.count[ref_idx][pred_idx]+=1;
-    }
-
-
-    pub fn get_tp(&self, idx: usize) -> u64
-    {
+    pub fn get_tp(&self, idx: usize) -> u64 {
         self.count[idx][idx]
     }
 
-    pub fn get_fp(&self, idx: usize) -> u64
-    {
+    pub fn get_fp(&self, idx: usize) -> u64 {
         let mut false_pos = 0;
-        for r in 0..idx
-            { false_pos +=self.count[r][idx]; }
+        for r in 0..idx {
+            false_pos += self.count[r][idx];
+        }
 
-        for r in idx+1..N
-            { false_pos +=self.count[r][idx]; }
+        for r in idx + 1..N {
+            false_pos += self.count[r][idx];
+        }
 
         false_pos
     }
 
-    pub fn get_fn(&self, idx: usize) -> u64
-    {
+    pub fn get_fn(&self, idx: usize) -> u64 {
         let mut false_neg = 0;
-        for p in 0..idx
-            { false_neg += self.count[idx][p]; }
+        for p in 0..idx {
+            false_neg += self.count[idx][p];
+        }
 
-        for p in idx+1 .. N
-            { false_neg += self.count[idx][p]; }
+        for p in idx + 1..N {
+            false_neg += self.count[idx][p];
+        }
 
         false_neg
     }
 
-
-
-    pub fn get_precision_recall_f1(&self, idx: usize) -> (f64, f64, f64)
-    {
+    pub fn get_precision_recall_f1(&self, idx: usize) -> (f64, f64, f64) {
         calc_precision_recall_f1(self.get_tp(idx), self.get_fp(idx), self.get_fn(idx))
     }
-
-
 }
 
-
-
-
 #[derive(Clone, Copy)]
-enum Annotation
-{
+enum Annotation {
     OutsideWindow,
     Filtered,
     Intergenic,
@@ -123,15 +107,12 @@ enum Annotation
     CodingPhase0,
     CodingPhase1,
     CodingPhase2,
-    Intron
+    Intron,
 }
 
-impl Annotation
-{
-    pub fn to_str(&self) -> &str
-    {
-        match self
-        {
+impl Annotation {
+    pub fn to_str(&self) -> &str {
+        match self {
             Annotation::OutsideWindow => "OutsideWindow",
             Annotation::Filtered => "Filtered",
             Annotation::Intergenic => "Intergenic",
@@ -143,10 +124,8 @@ impl Annotation
         }
     }
 
-    fn get_class_idx(self) -> usize
-    {
-        match self
-        {
+    fn get_class_idx(self) -> usize {
+        match self {
             Annotation::OutsideWindow => 0,
             Annotation::Filtered => 0,
             Annotation::Intergenic => 0,
@@ -158,10 +137,8 @@ impl Annotation
         }
     }
 
-    fn get_phase_idx(self) -> usize
-    {
-        match self
-        {
+    fn get_phase_idx(self) -> usize {
+        match self {
             Annotation::OutsideWindow => 0,
             Annotation::Filtered => 0,
             Annotation::Intergenic => 0,
@@ -174,97 +151,103 @@ impl Annotation
     }
 }
 
-impl ClassReference
-{
-    fn get_class_idx(&self) -> usize { self.get_max_idx() }
+impl ClassReference {
+    fn get_class_idx(&self) -> usize {
+        self.get_max_idx()
+    }
 }
 
-impl PhaseReference
-{
-    fn get_phase_idx(&self) -> usize { self.get_max_idx() }
+impl PhaseReference {
+    fn get_phase_idx(&self) -> usize {
+        self.get_max_idx()
+    }
 }
 
-
-impl ClassPrediction
-{
-    fn get_class_idx(&self) -> usize { self.get_max_idx() }
+impl ClassPrediction {
+    fn get_class_idx(&self) -> usize {
+        self.get_max_idx()
+    }
 }
 
-impl PhasePrediction
-{
-    fn get_phase_idx(&self) -> usize { self.get_max_idx() }
+impl PhasePrediction {
+    fn get_phase_idx(&self) -> usize {
+        self.get_max_idx()
+    }
 }
 
-
-
-
-
-pub struct SequenceRater<'a>
-{
+pub struct SequenceRater<'a> {
     comp_iterator: ComparisonIterator<'a>,
-    annotation: Vec<Annotation>
+    annotation: Vec<Annotation>,
 }
 
-impl<'a> SequenceRater<'a>
-{
-    pub fn new(comp_iterator: ComparisonIterator<'a>, seq_length: usize) -> SequenceRater<'a>
-    {
+impl<'a> SequenceRater<'a> {
+    pub fn new(comp_iterator: ComparisonIterator<'a>, seq_length: usize) -> SequenceRater<'a> {
         let mut annotation = Vec::with_capacity(seq_length);
         annotation.resize(seq_length, Annotation::OutsideWindow);
 
-        SequenceRater { comp_iterator, annotation }
+        SequenceRater {
+            comp_iterator,
+            annotation,
+        }
     }
 
-    pub fn rate_regions(&mut self, start_offset: usize, gene_regions: &[HmmStateRegion], filtered: bool)
-    {
-        if filtered
-            {
-            for region in gene_regions
+    pub fn rate_regions(
+        &mut self,
+        start_offset: usize,
+        gene_regions: &[HmmStateRegion],
+        filtered: bool,
+    ) {
+        if filtered {
+            for region in gene_regions {
+                for pos in
+                    region.get_start_pos() + start_offset..region.get_end_pos() + start_offset
                 {
-                for pos in region.get_start_pos() + start_offset..region.get_end_pos() + start_offset
-                    { self.annotation[pos] = Annotation::Filtered; }
+                    self.annotation[pos] = Annotation::Filtered;
                 }
             }
-        else
-            {
+        } else {
             let mut coding_annotation = Annotation::CodingPhase0;
 
-            for region in gene_regions
-            {
-                if region.get_annotation_label() != HmmAnnotationLabel::Coding
-                    {
-                    let annotation = match region.get_annotation_label()
-                        {
+            for region in gene_regions {
+                if region.get_annotation_label() != HmmAnnotationLabel::Coding {
+                    let annotation = match region.get_annotation_label() {
                         HmmAnnotationLabel::Intergenic => Annotation::Intergenic,
                         HmmAnnotationLabel::UTR5 => Annotation::UTR,
                         HmmAnnotationLabel::Intron => Annotation::Intron,
                         HmmAnnotationLabel::UTR3 => Annotation::UTR,
-                        _ => panic!("Unexpected Hmm Annotation Label {}", region.get_annotation_label().to_str())
-                        };
+                        _ => panic!(
+                            "Unexpected Hmm Annotation Label {}",
+                            region.get_annotation_label().to_str()
+                        ),
+                    };
 
-                    for pos in region.get_start_pos() + start_offset..region.get_end_pos() + start_offset
-                        { self.annotation[pos] = annotation; }
+                    for pos in
+                        region.get_start_pos() + start_offset..region.get_end_pos() + start_offset
+                    {
+                        self.annotation[pos] = annotation;
                     }
-                else {
-                    for pos in region.get_start_pos() + start_offset..region.get_end_pos() + start_offset
-                        {
+                } else {
+                    for pos in
+                        region.get_start_pos() + start_offset..region.get_end_pos() + start_offset
+                    {
                         self.annotation[pos] = coding_annotation;
 
-                        coding_annotation = match coding_annotation
-                            {
+                        coding_annotation = match coding_annotation {
                             Annotation::CodingPhase0 => Annotation::CodingPhase2,
                             Annotation::CodingPhase1 => Annotation::CodingPhase0,
                             Annotation::CodingPhase2 => Annotation::CodingPhase1,
-                            _ => panic!("Unexpected Coding Annotation Label {}", coding_annotation.to_str())
-                            }
+                            _ => panic!(
+                                "Unexpected Coding Annotation Label {}",
+                                coding_annotation.to_str()
+                            ),
                         }
                     }
                 }
             }
+        }
     }
 
-    pub fn calculate_stats(self) -> SequenceRating
-    {
+    pub fn calculate_stats(self) -> SequenceRating {
         let mut rating = SequenceRating::new();
         rating.rate(self.comp_iterator, self.annotation);
 
@@ -272,15 +255,11 @@ impl<'a> SequenceRater<'a>
     }
 }
 
-
-
-
 // Window States = Outside / Inside * Intergenic / Genic
 // Class = Intergenic / UTR / Coding / Intron
 // Phase = NonCoding / Ph0 / Ph1 / Ph2
 
-pub struct SequenceRating
-{
+pub struct SequenceRating {
     ref_ml_class_confusion: ConfusionMatrix<4>,
     ref_ml_phase_confusion: ConfusionMatrix<4>,
 
@@ -291,37 +270,44 @@ pub struct SequenceRating
     ml_hp_phase_confusion: ConfusionMatrix<4>,
 
     outside_window_count: u64,
-    filtered_count: u64
-
+    filtered_count: u64,
 }
 
-impl SequenceRating
-{
-    pub fn new() -> SequenceRating
-    {
-        SequenceRating { ref_ml_class_confusion: ConfusionMatrix::<4>::new(), ref_ml_phase_confusion: ConfusionMatrix::<4>::new(),
-            ref_hp_class_confusion: ConfusionMatrix::<4>::new(), ref_hp_phase_confusion: ConfusionMatrix::<4>::new(),
-            ml_hp_class_confusion: ConfusionMatrix::<4>::new(), ml_hp_phase_confusion: ConfusionMatrix::<4>::new(),
-            outside_window_count: 0, filtered_count: 0}
+impl SequenceRating {
+    pub fn new() -> SequenceRating {
+        SequenceRating {
+            ref_ml_class_confusion: ConfusionMatrix::<4>::new(),
+            ref_ml_phase_confusion: ConfusionMatrix::<4>::new(),
+            ref_hp_class_confusion: ConfusionMatrix::<4>::new(),
+            ref_hp_phase_confusion: ConfusionMatrix::<4>::new(),
+            ml_hp_class_confusion: ConfusionMatrix::<4>::new(),
+            ml_hp_phase_confusion: ConfusionMatrix::<4>::new(),
+            outside_window_count: 0,
+            filtered_count: 0,
+        }
     }
 
-    pub fn accumulate(&mut self, other: &Self)
-    {
-        self.ref_ml_class_confusion.accumulate(&other.ref_ml_class_confusion);
-        self.ref_ml_phase_confusion.accumulate(&other.ref_ml_phase_confusion);
+    pub fn accumulate(&mut self, other: &Self) {
+        self.ref_ml_class_confusion
+            .accumulate(&other.ref_ml_class_confusion);
+        self.ref_ml_phase_confusion
+            .accumulate(&other.ref_ml_phase_confusion);
 
-        self.ref_hp_class_confusion.accumulate(&other.ref_hp_class_confusion);
-        self.ref_hp_phase_confusion.accumulate(&other.ref_hp_phase_confusion);
+        self.ref_hp_class_confusion
+            .accumulate(&other.ref_hp_class_confusion);
+        self.ref_hp_phase_confusion
+            .accumulate(&other.ref_hp_phase_confusion);
 
-        self.ml_hp_class_confusion.accumulate(&other.ml_hp_class_confusion);
-        self.ml_hp_phase_confusion.accumulate(&other.ml_hp_phase_confusion);
+        self.ml_hp_class_confusion
+            .accumulate(&other.ml_hp_class_confusion);
+        self.ml_hp_phase_confusion
+            .accumulate(&other.ml_hp_phase_confusion);
 
         self.outside_window_count += other.outside_window_count;
         self.filtered_count += other.filtered_count;
     }
 
-    fn rate(&mut self, comp_iterator: ComparisonIterator, annotation: Vec<Annotation>)
-    {
+    fn rate(&mut self, comp_iterator: ComparisonIterator, annotation: Vec<Annotation>) {
         for ((class_ref, phase_ref, class_ml, phase_ml), annotation) in
             comp_iterator.zip(annotation.into_iter())
         {
@@ -334,174 +320,207 @@ impl SequenceRating
             let hp_class_idx = annotation.get_class_idx();
             let hp_phase_idx = annotation.get_phase_idx();
 
-            self.ref_ml_class_confusion.increment(ref_class_idx, ml_class_idx);
-            self.ref_ml_phase_confusion.increment(ref_phase_idx, ml_phase_idx);
+            self.ref_ml_class_confusion
+                .increment(ref_class_idx, ml_class_idx);
+            self.ref_ml_phase_confusion
+                .increment(ref_phase_idx, ml_phase_idx);
 
-            self.ref_hp_class_confusion.increment(ref_class_idx, hp_class_idx);
-            self.ref_hp_phase_confusion.increment(ref_phase_idx, hp_phase_idx);
+            self.ref_hp_class_confusion
+                .increment(ref_class_idx, hp_class_idx);
+            self.ref_hp_phase_confusion
+                .increment(ref_phase_idx, hp_phase_idx);
 
-            self.ml_hp_class_confusion.increment(ml_class_idx, hp_class_idx);
-            self.ml_hp_phase_confusion.increment(ml_phase_idx, hp_phase_idx);
+            self.ml_hp_class_confusion
+                .increment(ml_class_idx, hp_class_idx);
+            self.ml_hp_phase_confusion
+                .increment(ml_phase_idx, hp_phase_idx);
 
-            if ref_class_idx!=0
-                {
-                match annotation
-                    {
-                    Annotation::OutsideWindow => self.outside_window_count+=1,
-                    Annotation::Filtered => self.filtered_count+=1,
-                    _ => ()
-                    }
+            if ref_class_idx != 0 {
+                match annotation {
+                    Annotation::OutsideWindow => self.outside_window_count += 1,
+                    Annotation::Filtered => self.filtered_count += 1,
+                    _ => (),
                 }
-
+            }
         }
     }
 
+    const CLASS_NAMES: [&'static str; 4] = ["Intergenic", "UTR", "Coding", "Intron"];
+    const PHASE_NAMES: [&'static str; 4] = ["Non Coding", "Phase 0", "Phase 1", "Phase 2"];
 
-
-
-    const CLASS_NAMES: [&'static str; 4] = [ "Intergenic", "UTR", "Coding", "Intron" ];
-    const PHASE_NAMES: [&'static str; 4] = [ "Non Coding", "Phase 0", "Phase 1", "Phase 2" ];
-
-    pub fn show_confusion_matrices(class_confusion: &ConfusionMatrix<4>, phase_confusion: &ConfusionMatrix<4>, corner_label: &str)
-    {
+    pub fn show_confusion_matrices(
+        class_confusion: &ConfusionMatrix<4>,
+        phase_confusion: &ConfusionMatrix<4>,
+        corner_label: &str,
+    ) {
         /* Confusion Matrices, two column layout */
         print!("{:>10} Class\t", corner_label);
-        for j in 0..4
-            { print!("{:>12}\t", Self::CLASS_NAMES[j]); }
+        for j in 0..4 {
+            print!("{:>12}\t", Self::CLASS_NAMES[j]);
+        }
 
         print!("\t");
 
         print!("{:>10} Phase\t", corner_label);
-        for j in 0..4
-            { print!("{:>12}\t", Self::PHASE_NAMES[j]); }
+        for j in 0..4 {
+            print!("{:>12}\t", Self::PHASE_NAMES[j]);
+        }
 
         println!();
 
-        for i in 0..4
-            {
+        for i in 0..4 {
             print!("{:>16}\t", Self::CLASS_NAMES[i]);
-            for j in 0..4
-                { print!("{:12}\t", class_confusion.count[i][j]); }
+            for j in 0..4 {
+                print!("{:12}\t", class_confusion.count[i][j]);
+            }
 
             print!("\t");
 
             print!("{:>16}\t", Self::PHASE_NAMES[i]);
-            for j in 0..4
-                { print!("{:12}\t", phase_confusion.count[i][j]); }
+            for j in 0..4 {
+                print!("{:12}\t", phase_confusion.count[i][j]);
+            }
 
             println!();
-            }
+        }
 
         println!();
 
         /* Summaries, two column layout */
 
-        print!("{:>16}\t{:>12}\t{:>12}\t{:>12}\t{:>12}\t", "", "Precision", "Recall", "F1","");
+        print!(
+            "{:>16}\t{:>12}\t{:>12}\t{:>12}\t{:>12}\t",
+            "", "Precision", "Recall", "F1", ""
+        );
         print!("\t");
-        println!("{:>16}\t{:>12}\t{:>12}\t{:>12}\t{:>12}\t", "", "Precision", "Recall", "F1","");
+        println!(
+            "{:>16}\t{:>12}\t{:>12}\t{:>12}\t{:>12}\t",
+            "", "Precision", "Recall", "F1", ""
+        );
 
-        for i in 0..4
-            {
+        for i in 0..4 {
             let (prec, rec, f1) = class_confusion.get_precision_recall_f1(i);
-            print!("{:>16}\t{:12.5}\t{:12.5}\t{:12.5}\t{:>12}\t", Self::CLASS_NAMES[i], prec, rec, f1, "");
+            print!(
+                "{:>16}\t{:12.5}\t{:12.5}\t{:12.5}\t{:>12}\t",
+                Self::CLASS_NAMES[i],
+                prec,
+                rec,
+                f1,
+                ""
+            );
 
             print!("\t");
 
             let (prec, rec, f1) = phase_confusion.get_precision_recall_f1(i);
-            print!("{:>16}\t{:12.5}\t{:12.5}\t{:12.5}\t{:>12}\t", Self::PHASE_NAMES[i], prec, rec, f1, "");
+            print!(
+                "{:>16}\t{:12.5}\t{:12.5}\t{:12.5}\t{:>12}\t",
+                Self::PHASE_NAMES[i],
+                prec,
+                rec,
+                f1,
+                ""
+            );
 
             println!();
-            }
+        }
 
         println!();
 
-        let subg_true_pos = class_confusion.get_tp(2)+class_confusion.get_tp(3);
-        let subg_false_pos = class_confusion.get_fp(2)+class_confusion.get_fp(3);
-        let subg_false_neg = class_confusion.get_fn(2)+class_confusion.get_fn(3);
+        let subg_true_pos = class_confusion.get_tp(2) + class_confusion.get_tp(3);
+        let subg_false_pos = class_confusion.get_fp(2) + class_confusion.get_fp(3);
+        let subg_false_neg = class_confusion.get_fn(2) + class_confusion.get_fn(3);
 
-        let (subg_prec, subg_rec, subg_f1) = calc_precision_recall_f1(subg_true_pos, subg_false_pos, subg_false_neg);
+        let (subg_prec, subg_rec, subg_f1) =
+            calc_precision_recall_f1(subg_true_pos, subg_false_pos, subg_false_neg);
 
         let gen_true_pos = subg_true_pos + class_confusion.get_tp(1);
         let gen_false_pos = subg_false_pos + class_confusion.get_fp(1);
         let gen_false_neg = subg_false_neg + class_confusion.get_fn(1);
 
-        let (gen_prec, gen_rec, gen_f1) = calc_precision_recall_f1(gen_true_pos, gen_false_pos, gen_false_neg);
+        let (gen_prec, gen_rec, gen_f1) =
+            calc_precision_recall_f1(gen_true_pos, gen_false_pos, gen_false_neg);
 
-        let coding_true_pos = phase_confusion.get_tp(1)+phase_confusion.get_tp(2)+phase_confusion.get_tp(3);
-        let coding_false_pos = phase_confusion.get_fp(1)+phase_confusion.get_fp(2)+phase_confusion.get_fp(3);
-        let coding_false_neg = phase_confusion.get_fn(1)+phase_confusion.get_fn(2)+phase_confusion.get_fn(3);
+        let coding_true_pos =
+            phase_confusion.get_tp(1) + phase_confusion.get_tp(2) + phase_confusion.get_tp(3);
+        let coding_false_pos =
+            phase_confusion.get_fp(1) + phase_confusion.get_fp(2) + phase_confusion.get_fp(3);
+        let coding_false_neg =
+            phase_confusion.get_fn(1) + phase_confusion.get_fn(2) + phase_confusion.get_fn(3);
 
-        let (coding_prec, coding_rec, coding_f1) = calc_precision_recall_f1(coding_true_pos, coding_false_pos, coding_false_neg);
+        let (coding_prec, coding_rec, coding_f1) =
+            calc_precision_recall_f1(coding_true_pos, coding_false_pos, coding_false_neg);
 
-        print!("{:>16}\t{:12.5}\t{:12.5}\t{:12.5}\t{:>12}\t", "Subgenic", subg_prec, subg_rec, subg_f1, "");
+        print!(
+            "{:>16}\t{:12.5}\t{:12.5}\t{:12.5}\t{:>12}\t",
+            "Subgenic", subg_prec, subg_rec, subg_f1, ""
+        );
         print!("\t");
-        println!("{:>16}\t{:12.5}\t{:12.5}\t{:12.5}\t{:>12}\t", "Coding", coding_prec, coding_rec, coding_f1, "");
+        println!(
+            "{:>16}\t{:12.5}\t{:12.5}\t{:12.5}\t{:>12}\t",
+            "Coding", coding_prec, coding_rec, coding_f1, ""
+        );
 
-        println!("{:>16}\t{:12.5}\t{:12.5}\t{:12.5}\t", "Genic", gen_prec, gen_rec, gen_f1);
+        println!(
+            "{:>16}\t{:12.5}\t{:12.5}\t{:12.5}\t",
+            "Genic", gen_prec, gen_rec, gen_f1
+        );
 
         println!();
         println!();
     }
 
-    pub fn dump(&self, has_ref: bool)
-    {
-        if has_ref
-            {
-            println!("Lost Ref Genic: Outside Window {}, Filtered {}", self.outside_window_count, self.filtered_count);
+    pub fn dump(&self, has_ref: bool) {
+        if has_ref {
+            println!(
+                "Lost Ref Genic: Outside Window {}, Filtered {}",
+                self.outside_window_count, self.filtered_count
+            );
             println!();
 
-            Self::show_confusion_matrices(&self.ref_ml_class_confusion, &self.ref_ml_phase_confusion, "Ref v ML");
-            Self::show_confusion_matrices(&self.ref_hp_class_confusion, &self.ref_hp_phase_confusion, "Ref v HP");
-            }
-        Self::show_confusion_matrices(&self.ml_hp_class_confusion, &self.ml_hp_phase_confusion, "ML v HP");
+            Self::show_confusion_matrices(
+                &self.ref_ml_class_confusion,
+                &self.ref_ml_phase_confusion,
+                "Ref v ML",
+            );
+            Self::show_confusion_matrices(
+                &self.ref_hp_class_confusion,
+                &self.ref_hp_phase_confusion,
+                "Ref v HP",
+            );
+        }
+        Self::show_confusion_matrices(
+            &self.ml_hp_class_confusion,
+            &self.ml_hp_phase_confusion,
+            "ML v HP",
+        );
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 #[cfg(test)]
 mod tests {
     use crate::analysis::rater::ConfusionMatrix;
 
     #[test]
-    fn test_confusion_empty_matrix()
-    {
+    fn test_confusion_empty_matrix() {
         let empty_matrix = ConfusionMatrix::<3>::new();
         assert_eq!(empty_matrix.size(), 3);
 
-        for i in 0..3
-            {
+        for i in 0..3 {
             assert_eq!(empty_matrix.get_tp(i), 0);
             assert_eq!(empty_matrix.get_fp(i), 0);
             assert_eq!(empty_matrix.get_fn(i), 0);
-            }
+        }
     }
 
     #[test]
-    fn test_confusion_perfect_matrix()
-    {
+    fn test_confusion_perfect_matrix() {
         let mut matrix = ConfusionMatrix::<3>::new();
 
-        for i in 0..3
-            { matrix.increment(i,i); }
+        for i in 0..3 {
+            matrix.increment(i, i);
+        }
 
-        for i in 0..3
-        {
+        for i in 0..3 {
             assert_eq!(matrix.get_tp(i), 1);
             assert_eq!(matrix.get_fp(i), 0);
             assert_eq!(matrix.get_fn(i), 0);
@@ -509,31 +528,28 @@ mod tests {
     }
 
     #[test]
-    fn test_confusion_fp_matrix()
-    {
-        for i in 0..3
-            {
+    fn test_confusion_fp_matrix() {
+        for i in 0..3 {
             let mut matrix = ConfusionMatrix::<3>::new();
 
-            for j in 0..3
-                { matrix.increment(j, i); } // Same pred for all refs
+            for j in 0..3 {
+                matrix.increment(j, i);
+            } // Same pred for all refs
 
             assert_eq!(matrix.get_tp(i), 1);
             assert_eq!(matrix.get_fp(i), 2);
             assert_eq!(matrix.get_fn(i), 0);
-            }
+        }
     }
 
-
     #[test]
-    fn test_confusion_fn_matrix()
-    {
-        for i in 0..3
-        {
+    fn test_confusion_fn_matrix() {
+        for i in 0..3 {
             let mut matrix = ConfusionMatrix::<3>::new();
 
-            for j in 0..3
-                { matrix.increment(i, j); } // Same pred for all refs
+            for j in 0..3 {
+                matrix.increment(i, j);
+            } // Same pred for all refs
 
             assert_eq!(matrix.get_tp(i), 1);
             assert_eq!(matrix.get_fp(i), 0);
@@ -541,8 +557,3 @@ mod tests {
         }
     }
 }
-
-
-
-
-

--- a/helixer_post_bin/src/analysis/window.rs
+++ b/helixer_post_bin/src/analysis/window.rs
@@ -1,10 +1,13 @@
 use crate::analysis::extractor::BasePredictionIterator;
-use crate::results::conv::{Bases, ClassPrediction, PhasePrediction, ArrayConvInto};
-use std::collections::VecDeque;
+use crate::results::conv::{ArrayConvInto, Bases, ClassPrediction, PhasePrediction};
 use std::collections::vec_deque::Iter;
+use std::collections::VecDeque;
 
-pub struct BasePredictionWindow<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
-{
+pub struct BasePredictionWindow<
+    'a,
+    TC: ArrayConvInto<ClassPrediction>,
+    TP: ArrayConvInto<PhasePrediction>,
+> {
     bp_iter: BasePredictionIterator<'a, TC, TP>,
 
     window_size: usize,
@@ -12,84 +15,104 @@ pub struct BasePredictionWindow<'a, TC: ArrayConvInto<ClassPrediction>, TP: Arra
     window_total: u64,
 
     window: VecDeque<(Bases, ClassPrediction, PhasePrediction)>,
-    position: usize
+    position: usize,
 }
 
-impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> BasePredictionWindow<'a, TC, TP>
+impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
+    BasePredictionWindow<'a, TC, TP>
 {
-    pub fn new(bp_iter: BasePredictionIterator<'a, TC, TP>, window_size: usize, scale: f32) -> Option<BasePredictionWindow<'a, TC, TP>>
-    {
+    pub fn new(
+        bp_iter: BasePredictionIterator<'a, TC, TP>,
+        window_size: usize,
+        scale: f32,
+    ) -> Option<BasePredictionWindow<'a, TC, TP>> {
         let window = VecDeque::with_capacity(window_size);
 
-        let mut bp_window = BasePredictionWindow { bp_iter, window_size, scale, window_total: 0, window, position: 0 };
+        let mut bp_window = BasePredictionWindow {
+            bp_iter,
+            window_size,
+            scale,
+            window_total: 0,
+            window,
+            position: 0,
+        };
         bp_window.fill_window();
 
         Some(bp_window)
     }
 
-    fn fill_window(&mut self) -> bool
-    {
-        while self.window.len() < self.window_size
-        { if !self.push() { return false; } }
+    fn fill_window(&mut self) -> bool {
+        while self.window.len() < self.window_size {
+            if !self.push() {
+                return false;
+            }
+        }
         true
     }
 
-    fn push(&mut self) -> bool
-    {
+    fn push(&mut self) -> bool {
         let maybe_next = self.bp_iter.next();
 
-        if let Some((bases, class_pred, phase_pred)) = maybe_next
-        {
-            self.window_total+= (class_pred.get_genic() * self.scale) as u64;
+        if let Some((bases, class_pred, phase_pred)) = maybe_next {
+            self.window_total += (class_pred.get_genic() * self.scale) as u64;
             self.window.push_back((bases, class_pred, phase_pred));
             true
+        } else {
+            false
         }
-        else
-        { false }
-
     }
 
-    fn pop(&mut self) -> Option<(Bases, ClassPrediction, PhasePrediction)>
-    {
+    fn pop(&mut self) -> Option<(Bases, ClassPrediction, PhasePrediction)> {
         let maybe_next = self.window.pop_front();
 
-        if let Some((_bases, class_pred, _phase_pred)) = &maybe_next
-        {
+        if let Some((_bases, class_pred, _phase_pred)) = &maybe_next {
             self.window_total -= (class_pred.get_genic() * self.scale) as u64;
-            self.position+=1;
+            self.position += 1;
         }
 
         maybe_next
     }
 
-    pub fn get_window_total(&self) -> u64 { self.window_total }
-
-    pub fn is_window_full(&self) -> bool { self.window.len()==self.window_size }
-
-    pub fn get_window_iter(&self) -> Iter<(Bases, ClassPrediction, PhasePrediction)> { self.window.iter() }
-}
-
-
-
-pub struct BasePredictionWindowThresholdScanner<'a,  TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
-{
-    bp_window: BasePredictionWindow<'a, TC, TP>,
-    edge_threshold: u64
-}
-
-
-impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> BasePredictionWindowThresholdScanner<'a, TC, TP>
-{
-    pub fn new(bp_window: BasePredictionWindow<'a, TC, TP>, edge_threshold: f32) -> BasePredictionWindowThresholdScanner<'a, TC, TP>
-    {
-        let threshold = (edge_threshold * bp_window.scale * (bp_window.window_size as f32)) as u64;
-
-        BasePredictionWindowThresholdScanner { bp_window, edge_threshold: threshold }
+    pub fn get_window_total(&self) -> u64 {
+        self.window_total
     }
 
-    fn scan_for_start(&mut self) -> bool
-    {
-        while self.bp_window.is_window_full() && self.bp_window.get_window_total() < self.edge_threshold
+    pub fn is_window_full(&self) -> bool {
+        self.window.len() == self.window_size
+    }
+
+    pub fn get_window_iter(&self) -> Iter<(Bases, ClassPrediction, PhasePrediction)> {
+        self.window.iter()
+    }
+}
+
+pub struct BasePredictionWindowThresholdScanner<
+    'a,
+    TC: ArrayConvInto<ClassPrediction>,
+    TP: ArrayConvInto<PhasePrediction>,
+> {
+    bp_window: BasePredictionWindow<'a, TC, TP>,
+    edge_threshold: u64,
+}
+
+impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
+    BasePredictionWindowThresholdScanner<'a, TC, TP>
+{
+    pub fn new(
+        bp_window: BasePredictionWindow<'a, TC, TP>,
+        edge_threshold: f32,
+    ) -> BasePredictionWindowThresholdScanner<'a, TC, TP> {
+        let threshold = (edge_threshold * bp_window.scale * (bp_window.window_size as f32)) as u64;
+
+        BasePredictionWindowThresholdScanner {
+            bp_window,
+            edge_threshold: threshold,
+        }
+    }
+
+    fn scan_for_start(&mut self) -> bool {
+        while self.bp_window.is_window_full()
+            && self.bp_window.get_window_total() < self.edge_threshold
         {
             self.bp_window.pop(); // Pop and discard
             self.bp_window.push();
@@ -98,18 +121,28 @@ impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
         self.bp_window.is_window_full()
     }
 
-    fn accumulate_above_threshold(&mut self) -> (Vec<(Bases, ClassPrediction, PhasePrediction)>, Vec<u64>, usize, u64)
-    {
-        let mut accum=Vec::new();
-        let mut total_accum=Vec::new();
+    fn accumulate_above_threshold(
+        &mut self,
+    ) -> (
+        Vec<(Bases, ClassPrediction, PhasePrediction)>,
+        Vec<u64>,
+        usize,
+        u64,
+    ) {
+        let mut accum = Vec::new();
+        let mut total_accum = Vec::new();
 
-        if !self.bp_window.is_window_full() || self.bp_window.get_window_total() < self.edge_threshold
-        { panic!("Accumulate called with window not past threshold"); }
+        if !self.bp_window.is_window_full()
+            || self.bp_window.get_window_total() < self.edge_threshold
+        {
+            panic!("Accumulate called with window not past threshold");
+        }
 
         let mut peak = 0;
         let position = self.bp_window.position;
 
-        while self.bp_window.is_window_full() && self.bp_window.get_window_total() >= self.edge_threshold
+        while self.bp_window.is_window_full()
+            && self.bp_window.get_window_total() >= self.edge_threshold
         {
             let total = self.bp_window.get_window_total();
             total_accum.push(total);
@@ -121,64 +154,85 @@ impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
             self.bp_window.push();
         }
 
-        for (b,cp, pp) in self.bp_window.get_window_iter()
-        { accum.push((*b, *cp, *pp)) }
+        for (b, cp, pp) in self.bp_window.get_window_iter() {
+            accum.push((*b, *cp, *pp))
+        }
 
-        if self.bp_window.is_window_full()  // If window is still full, the last element crossed below the threshold, remove it
-        { accum.pop(); }
+        if self.bp_window.is_window_full()
+        // If window is still full, the last element crossed below the threshold, remove it
+        {
+            accum.pop();
+        }
 
         (accum, total_accum, position, peak)
     }
-
 }
-
 
 const THRESHOLD_SCALE: f32 = 1_000_000.0;
 
-pub struct BasePredictionWindowThresholdIterator<'a,  TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
-{
+pub struct BasePredictionWindowThresholdIterator<
+    'a,
+    TC: ArrayConvInto<ClassPrediction>,
+    TP: ArrayConvInto<PhasePrediction>,
+> {
     bp_scanner: BasePredictionWindowThresholdScanner<'a, TC, TP>,
     peak_threshold: u64,
-    peak_scale: f32
+    peak_scale: f32,
 }
 
-impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> BasePredictionWindowThresholdIterator<'a, TC, TP>
+impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>>
+    BasePredictionWindowThresholdIterator<'a, TC, TP>
 {
-    pub fn new(bp_iter: BasePredictionIterator<'a, TC, TP>, window_size: usize, edge_threshold: f32, peak_threshold: f32) -> Option<BasePredictionWindowThresholdIterator<'a, TC, TP>>
-    {
+    pub fn new(
+        bp_iter: BasePredictionIterator<'a, TC, TP>,
+        window_size: usize,
+        edge_threshold: f32,
+        peak_threshold: f32,
+    ) -> Option<BasePredictionWindowThresholdIterator<'a, TC, TP>> {
         let bp_window = BasePredictionWindow::new(bp_iter, window_size, THRESHOLD_SCALE);
-        if bp_window.is_none()
-        { return None; }
+        if bp_window.is_none() {
+            return None;
+        }
 
-        let bp_window=bp_window.unwrap();
+        let bp_window = bp_window.unwrap();
         let bp_scanner = BasePredictionWindowThresholdScanner::new(bp_window, edge_threshold);
 
         let window_size = window_size as f32;
 
         let peak_threshold = (peak_threshold * THRESHOLD_SCALE * window_size) as u64;
-        let peak_scale = 1.0 / (THRESHOLD_SCALE*window_size);
+        let peak_scale = 1.0 / (THRESHOLD_SCALE * window_size);
 
-        Some (BasePredictionWindowThresholdIterator { bp_scanner, peak_threshold, peak_scale })
+        Some(BasePredictionWindowThresholdIterator {
+            bp_scanner,
+            peak_threshold,
+            peak_scale,
+        })
     }
 }
 
-impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> Iterator for BasePredictionWindowThresholdIterator<'a, TC, TP>
+impl<'a, TC: ArrayConvInto<ClassPrediction>, TP: ArrayConvInto<PhasePrediction>> Iterator
+    for BasePredictionWindowThresholdIterator<'a, TC, TP>
 {
-    type Item = (Vec<(Bases, ClassPrediction, PhasePrediction)>, Vec<u64>, usize, f32);
+    type Item = (
+        Vec<(Bases, ClassPrediction, PhasePrediction)>,
+        Vec<u64>,
+        usize,
+        f32,
+    );
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            if !self.bp_scanner.scan_for_start()
-            { return None; }
+            if !self.bp_scanner.scan_for_start() {
+                return None;
+            }
 
-            let (bp_accum, total_accum, position, peak) = self.bp_scanner.accumulate_above_threshold();
+            let (bp_accum, total_accum, position, peak) =
+                self.bp_scanner.accumulate_above_threshold();
 
-            if peak > self.peak_threshold
-            {
-                let peak = (peak as f32)*self.peak_scale;
-                return Some((bp_accum, total_accum, position, peak)); }
+            if peak > self.peak_threshold {
+                let peak = (peak as f32) * self.peak_scale;
+                return Some((bp_accum, total_accum, position, peak));
+            }
         }
-
     }
 }
-

--- a/helixer_post_bin/src/gff.rs
+++ b/helixer_post_bin/src/gff.rs
@@ -1,26 +1,19 @@
-
-
-
-use std::io::{BufWriter, Write};
 use std::fmt::{Display, Formatter};
+use std::io::{BufWriter, Write};
 
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub enum GffFeature
-{
+pub enum GffFeature {
     Gene,
     MRNA,
     Exon,
     FivePrimeUTR,
     CDS,
-    ThreePrimeUTR
+    ThreePrimeUTR,
 }
 
-impl GffFeature
-{
-    pub fn as_str(self) -> &'static str
-    {
-        match self
-        {
+impl GffFeature {
+    pub fn as_str(self) -> &'static str {
+        match self {
             GffFeature::Gene => "gene",
             GffFeature::MRNA => "mRNA",
             GffFeature::Exon => "exon",
@@ -31,83 +24,69 @@ impl GffFeature
     }
 }
 
-impl Display for GffFeature
-{
+impl Display for GffFeature {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }
 }
 
-
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub enum GffStrand
-{
+pub enum GffStrand {
     Forward,
-    Reverse
+    Reverse,
 }
 
-impl GffStrand
-{
-    pub fn other(self) -> GffStrand
-    {
-        match self
-        {
+impl GffStrand {
+    pub fn other(self) -> GffStrand {
+        match self {
             GffStrand::Forward => GffStrand::Reverse,
             GffStrand::Reverse => GffStrand::Forward,
         }
     }
 
-    pub fn from_rev(rev: bool) -> GffStrand { if rev { GffStrand::Reverse } else { GffStrand::Forward } }
+    pub fn from_rev(rev: bool) -> GffStrand {
+        if rev {
+            GffStrand::Reverse
+        } else {
+            GffStrand::Forward
+        }
+    }
 
-    pub fn as_str(self) -> &'static str
-    {
-        match self
-        {
+    pub fn as_str(self) -> &'static str {
+        match self {
             GffStrand::Forward => "+",
             GffStrand::Reverse => "-",
         }
     }
 }
 
-
-
-
-
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub enum GffPhase
-{
-    Zero=0,
-    One=1,
-    Two=2
+pub enum GffPhase {
+    Zero = 0,
+    One = 1,
+    Two = 2,
 }
 
-impl GffPhase
-{
-    pub fn as_str(self) -> &'static str
-    {
-        match self
-        {
+impl GffPhase {
+    pub fn as_str(self) -> &'static str {
+        match self {
             GffPhase::Zero => "0",
             GffPhase::One => "1",
-            GffPhase::Two => "2"
+            GffPhase::Two => "2",
         }
     }
 }
 
-
-impl From<u64> for GffPhase
-{
+impl From<u64> for GffPhase {
     fn from(offset: u64) -> Self {
-        match offset % 3
-            {
+        match offset % 3 {
             0 => GffPhase::Zero,
             1 => GffPhase::Two, // Phase means 'bases left to read', so counts down - Because biology
             2 => GffPhase::One,
-            _ => panic!("Math is broken")
-            }
+            _ => panic!("Math is broken"),
+        }
     }
 }
-
 
 /*
 
@@ -123,10 +102,7 @@ impl From<u64> for GffPhase
 
  */
 
-
-
-pub struct GffRecord
-{
+pub struct GffRecord {
     sequence: String,
     source: String,
     feature: GffFeature,
@@ -135,77 +111,113 @@ pub struct GffRecord
     score: Option<f32>,
     strand: Option<GffStrand>,
     phase: Option<GffPhase>,
-    attributes: String
+    attributes: String,
 }
 
-impl GffRecord
-{
-    pub fn new(sequence: String, source: String, feature: GffFeature, start: u64, end: u64, score: Option<f32>,
-               strand: Option<GffStrand>, phase: Option<GffPhase>, attributes: String) -> GffRecord
-    {
-        GffRecord { sequence, source, feature, start, end, score, strand, phase, attributes }
+impl GffRecord {
+    pub fn new(
+        sequence: String,
+        source: String,
+        feature: GffFeature,
+        start: u64,
+        end: u64,
+        score: Option<f32>,
+        strand: Option<GffStrand>,
+        phase: Option<GffPhase>,
+        attributes: String,
+    ) -> GffRecord {
+        GffRecord {
+            sequence,
+            source,
+            feature,
+            start,
+            end,
+            score,
+            strand,
+            phase,
+            attributes,
+        }
     }
 
-    pub fn swap_strand(&mut self, len: u64)
-    {
+    pub fn swap_strand(&mut self, len: u64) {
         let start = self.start;
         let end = self.end;
 
-        self.end=1+len-start;
-        self.start=1+len-end;
+        self.end = 1 + len - start;
+        self.start = 1 + len - end;
 
-        if let Some(strand) = self.strand { self.strand=Some(strand.other())} ;
+        if let Some(strand) = self.strand {
+            self.strand = Some(strand.other())
+        };
     }
 
-    pub fn get_sequence(&self) -> &String { &self.sequence }
+    pub fn get_sequence(&self) -> &String {
+        &self.sequence
+    }
 
-    pub fn get_source(&self) -> &String { &self.source }
+    pub fn get_source(&self) -> &String {
+        &self.source
+    }
 
-    pub fn get_start(&self) -> u64 { self.start }
+    pub fn get_start(&self) -> u64 {
+        self.start
+    }
 
-    pub fn get_end(&self) -> u64 { self.end }
+    pub fn get_end(&self) -> u64 {
+        self.end
+    }
 
-    pub fn get_score(&self) -> Option<f32> { self.score }
+    pub fn get_score(&self) -> Option<f32> {
+        self.score
+    }
 
-    pub fn get_strand(&self) -> Option<GffStrand> { self.strand }
+    pub fn get_strand(&self) -> Option<GffStrand> {
+        self.strand
+    }
 
-    pub fn get_phase(&self) -> Option<GffPhase> { self.phase }
+    pub fn get_phase(&self) -> Option<GffPhase> {
+        self.phase
+    }
 
-    pub fn get_attributes(&self) -> &String { &self.attributes }
-
-
-
+    pub fn get_attributes(&self) -> &String {
+        &self.attributes
+    }
 }
 
-
-pub struct GffWriter<W: Write>
-{
-    writer: BufWriter<W>
+pub struct GffWriter<W: Write> {
+    writer: BufWriter<W>,
 }
 
-impl<W: Write> GffWriter<W>
-{
-    pub fn new(writer: BufWriter<W>) -> GffWriter<W>
-    {
+impl<W: Write> GffWriter<W> {
+    pub fn new(writer: BufWriter<W>) -> GffWriter<W> {
         GffWriter { writer }
     }
 
-    pub fn write_record(&mut self, rec: & GffRecord) -> std::io::Result<()>
-    {
-        let score = rec.score.map_or(".".to_owned(), |v| {format!("{}", v)});
-        let strand = rec.strand.map_or(".", |v| { v.as_str() });
-        let phase = rec.phase.map_or(".", |v| { v.as_str() });
+    pub fn write_record(&mut self, rec: &GffRecord) -> std::io::Result<()> {
+        let score = rec.score.map_or(".".to_owned(), |v| format!("{}", v));
+        let strand = rec.strand.map_or(".", |v| v.as_str());
+        let phase = rec.phase.map_or(".", |v| v.as_str());
 
-        write!(self.writer, "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
-                       rec.sequence, rec.source, rec.feature, rec.start, rec.end, score, strand, phase, rec.attributes)
+        write!(
+            self.writer,
+            "{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\t{}\n",
+            rec.sequence,
+            rec.source,
+            rec.feature,
+            rec.start,
+            rec.end,
+            score,
+            strand,
+            phase,
+            rec.attributes
+        )
     }
 
-    pub fn write_records(&mut self, recs: & [GffRecord]) -> std::io::Result<()>
-    {
-        for rec in recs
-            { self.write_record(rec)? }
+    pub fn write_records(&mut self, recs: &[GffRecord]) -> std::io::Result<()> {
+        for rec in recs {
+            self.write_record(rec)?
+        }
 
         Ok(())
     }
 }
-

--- a/helixer_post_bin/src/lib.rs
+++ b/helixer_post_bin/src/lib.rs
@@ -1,6 +1,3 @@
-
 pub mod analysis;
 pub mod gff;
 pub mod results;
-
-

--- a/helixer_post_bin/src/main.rs
+++ b/helixer_post_bin/src/main.rs
@@ -1,21 +1,17 @@
-
-use std::process::exit;
-use std::fs::File;
-use helixer_post_bin::results::HelixerResults;
+use helixer_post_bin::analysis::extractor::{BasePredictionExtractor, ComparisonExtractor};
 use helixer_post_bin::analysis::hmm::show_hmm_config;
-use helixer_post_bin::gff::GffWriter;
-use std::io::BufWriter;
 use helixer_post_bin::analysis::rater::SequenceRating;
-use helixer_post_bin::analysis::extractor::{ComparisonExtractor, BasePredictionExtractor};
 use helixer_post_bin::analysis::Analyzer;
+use helixer_post_bin::gff::GffWriter;
+use helixer_post_bin::results::HelixerResults;
+use std::fs::File;
+use std::io::BufWriter;
+use std::process::exit;
 
-
-fn main()
-{
+fn main() {
     let arg_vec = std::env::args().collect::<Vec<_>>(); // Arg iterator into vector
 
-    if arg_vec.len() != 8
-    {
+    if arg_vec.len() != 8 {
         println!("HelixerPost <genome.h5> <predictions.h5> <windowSize> <edgeThresh> <peakThresh> <minCodingLength> <gff>");
         exit(1);
     }
@@ -28,14 +24,23 @@ fn main()
     let min_coding_length = arg_vec[6].parse().unwrap();
     let gff_filename = &arg_vec[7];
 
-    let helixer_res = HelixerResults::new(predictions_path.as_ref(), genome_path.as_ref()).expect("Failed to open input files");
+    let helixer_res = HelixerResults::new(predictions_path.as_ref(), genome_path.as_ref())
+        .expect("Failed to open input files");
 
-    let bp_extractor = BasePredictionExtractor::new_from_prediction(&helixer_res).expect("Failed to open Base / ClassPrediction / PhasePrediction Datasets");
+    let bp_extractor = BasePredictionExtractor::new_from_prediction(&helixer_res)
+        .expect("Failed to open Base / ClassPrediction / PhasePrediction Datasets");
     //let bp_extractor = BasePredictionExtractor::new_from_pseudo_predictions(&helixer_res).expect("Failed to open Base / ClassPrediction / PhasePrediction Datasets");
 
     let comp_extractor = ComparisonExtractor::new(&helixer_res).expect("Failed to open ClassReference / PhaseReference / ClassPrediction / PhasePrediction Datasets");
 
-    let analyzer = Analyzer::new(bp_extractor, comp_extractor, window_size, edge_threshold, peak_threshold, min_coding_length);
+    let analyzer = Analyzer::new(
+        bp_extractor,
+        comp_extractor,
+        window_size,
+        edge_threshold,
+        peak_threshold,
+        min_coding_length,
+    );
 
     let mut total_count = 0;
     let mut total_length = 0;
@@ -45,37 +50,51 @@ fn main()
     let gff_file = File::create(gff_filename).unwrap();
     let mut gff_writer = GffWriter::new(BufWriter::new(gff_file));
 
-    for species in helixer_res.get_all_species()
-    {
+    for species in helixer_res.get_all_species() {
         let mut fwd_species_rating = SequenceRating::new();
         let mut rev_species_rating = SequenceRating::new();
 
         let id = species.get_id();
-        println!("Sequences for Species {} - {}", species.get_name(), id.inner() );
-        for seq_id in helixer_res.get_sequences_for_species(id)
-        {
+        println!(
+            "Sequences for Species {} - {}",
+            species.get_name(),
+            id.inner()
+        );
+        for seq_id in helixer_res.get_sequences_for_species(id) {
             let seq = helixer_res.get_sequence_by_id(*seq_id);
-            let (count, length) = analyzer.process_sequence(species, seq, &mut fwd_species_rating, &mut rev_species_rating, &mut gff_writer);
+            let (count, length) = analyzer.process_sequence(
+                species,
+                seq,
+                &mut fwd_species_rating,
+                &mut rev_species_rating,
+                &mut gff_writer,
+            );
 
-            total_count+=count;
-            total_length+=length;
+            total_count += count;
+            total_length += length;
         }
 
-        println!("Forward for Species {} - {}", species.get_name(), id.inner() );
+        println!(
+            "Forward for Species {} - {}",
+            species.get_name(),
+            id.inner()
+        );
         fwd_species_rating.dump(analyzer.has_ref());
 
-        println!("Reverse for Species {} - {}", species.get_name(), id.inner() );
+        println!(
+            "Reverse for Species {} - {}",
+            species.get_name(),
+            id.inner()
+        );
         rev_species_rating.dump(analyzer.has_ref());
 
         let mut species_rating = SequenceRating::new();
         species_rating.accumulate(&fwd_species_rating);
         species_rating.accumulate(&rev_species_rating);
 
-        println!("Total for Species {} - {}", species.get_name(), id.inner() );
+        println!("Total for Species {} - {}", species.get_name(), id.inner());
         species_rating.dump(analyzer.has_ref());
     }
 
     println!("Total: {}bp across {} windows", total_length, total_count);
-
-
 }

--- a/helixer_post_bin/src/results.rs
+++ b/helixer_post_bin/src/results.rs
@@ -9,240 +9,293 @@ pub mod raw;
 pub use crate::results::error::Error;
 pub type Result<T> = std::result::Result<T, Error>;
 
-use self::raw::{RawHelixerPredictions, RawHelixerGenome};
 use self::index::HelixerIndex;
-use crate::results::iter::{BlockedDataset2D, BlockedDataset1D};
-use crate::results::conv::{ClassPrediction, Bases, ClassReference, Transitions, PhasePrediction, PhaseReference};
+use self::raw::{RawHelixerGenome, RawHelixerPredictions};
+use crate::results::conv::{
+    Bases, ClassPrediction, ClassReference, PhasePrediction, PhaseReference, Transitions,
+};
+use crate::results::iter::{BlockedDataset1D, BlockedDataset2D};
 
-
-pub struct HelixerResults
-{
+pub struct HelixerResults {
     predictions: RawHelixerPredictions,
     genome: RawHelixerGenome,
 
-    index: HelixerIndex
+    index: HelixerIndex,
 }
 
-
-impl HelixerResults
-{
-    pub fn new(predictions_path: &Path, genome_path: &Path) -> Result<HelixerResults>
-    {
+impl HelixerResults {
+    pub fn new(predictions_path: &Path, genome_path: &Path) -> Result<HelixerResults> {
         let predictions = RawHelixerPredictions::new(predictions_path)?;
         let (blocks, blocksize) = predictions.get_blocks_and_blocksize()?;
         let genome = RawHelixerGenome::new(genome_path, blocks, blocksize)?;
 
         let index = HelixerIndex::new(&genome)?;
 
-        Ok(HelixerResults { predictions, genome, index })
+        Ok(HelixerResults {
+            predictions,
+            genome,
+            index,
+        })
     }
 
-    pub fn get_raw_predictions(&self) -> &RawHelixerPredictions { &self.predictions }
+    pub fn get_raw_predictions(&self) -> &RawHelixerPredictions {
+        &self.predictions
+    }
 
-    pub fn get_raw_genome(&self) -> &RawHelixerGenome { &self.genome }
+    pub fn get_raw_genome(&self) -> &RawHelixerGenome {
+        &self.genome
+    }
 
-    pub fn get_index(&self) -> &HelixerIndex { &self.index }
+    pub fn get_index(&self) -> &HelixerIndex {
+        &self.index
+    }
 
     // Delegate species/sequence/block lookups to Index
 
-    pub fn get_all_species(&self) -> &[Species] { self.index.get_all_species() }
+    pub fn get_all_species(&self) -> &[Species] {
+        self.index.get_all_species()
+    }
 
-    pub fn get_species_by_id (&self, id: SpeciesID) -> &Species { self.index.get_species_by_id(id) }
+    pub fn get_species_by_id(&self, id: SpeciesID) -> &Species {
+        self.index.get_species_by_id(id)
+    }
 
-    pub fn get_species_by_name (&self, name: &str) -> Option<&Species>
-    {
+    pub fn get_species_by_name(&self, name: &str) -> Option<&Species> {
         self.index.get_species_by_name(name)
     }
 
-    pub fn get_all_sequences(&self) -> &[Sequence] { self.index.get_all_sequences() }
-
-    pub fn get_sequence_by_id(&self, id: SequenceID) -> &Sequence { self.index.get_sequence_by_id(id) }
-
-    pub fn get_sequence_by_species_id_and_sequence_name(&self, species_id: SpeciesID, sequence_name: &str) -> Option<&Sequence>
-    {
-        self.index.get_sequence_by_species_id_and_sequence_name(species_id, sequence_name)
+    pub fn get_all_sequences(&self) -> &[Sequence] {
+        self.index.get_all_sequences()
     }
 
-    pub fn get_sequences_for_all_species(&self) -> &[Vec<SequenceID>] { self.index.get_sequences_for_all_species() }
+    pub fn get_sequence_by_id(&self, id: SequenceID) -> &Sequence {
+        self.index.get_sequence_by_id(id)
+    }
 
-    pub fn get_sequences_for_species(&self, id: SpeciesID) -> &[SequenceID] { self.index.get_sequences_for_species(id) }
+    pub fn get_sequence_by_species_id_and_sequence_name(
+        &self,
+        species_id: SpeciesID,
+        sequence_name: &str,
+    ) -> Option<&Sequence> {
+        self.index
+            .get_sequence_by_species_id_and_sequence_name(species_id, sequence_name)
+    }
 
-    pub fn get_all_block_offsets(&self) -> &[(u64, u64)] { self.index.get_all_block_offsets() }
+    pub fn get_sequences_for_all_species(&self) -> &[Vec<SequenceID>] {
+        self.index.get_sequences_for_all_species()
+    }
 
-    pub fn get_all_block_ids(&self) -> &[(Vec<BlockID>, Vec<BlockID>)] { self.index.get_all_block_ids() }
+    pub fn get_sequences_for_species(&self, id: SpeciesID) -> &[SequenceID] {
+        self.index.get_sequences_for_species(id)
+    }
 
-    pub fn get_block_ids_for_sequence(&self, id: SequenceID) -> &(Vec<BlockID>, Vec<BlockID>) { self.index.get_block_ids_for_sequence(id) }
+    pub fn get_all_block_offsets(&self) -> &[(u64, u64)] {
+        self.index.get_all_block_offsets()
+    }
 
+    pub fn get_all_block_ids(&self) -> &[(Vec<BlockID>, Vec<BlockID>)] {
+        self.index.get_all_block_ids()
+    }
+
+    pub fn get_block_ids_for_sequence(&self, id: SequenceID) -> &(Vec<BlockID>, Vec<BlockID>) {
+        self.index.get_block_ids_for_sequence(id)
+    }
 
     // Wrapped dataset accessors for large datasets, delegate smaller datasets to standard collection converters
 
-    pub fn get_class_predictions(&self) -> Result<BlockedDataset2D<f32, ClassPrediction>>
-    {
-        Ok(BlockedDataset2D::new(&self.index, self.predictions.get_class_raw()?))
+    pub fn get_class_predictions(&self) -> Result<BlockedDataset2D<f32, ClassPrediction>> {
+        Ok(BlockedDataset2D::new(
+            &self.index,
+            self.predictions.get_class_raw()?,
+        ))
     }
 
-    pub fn get_phase_predictions(&self) -> Result<BlockedDataset2D<f32, PhasePrediction>>
-    {
-        Ok(BlockedDataset2D::new(&self.index, self.predictions.get_phase_raw()?))
+    pub fn get_phase_predictions(&self) -> Result<BlockedDataset2D<f32, PhasePrediction>> {
+        Ok(BlockedDataset2D::new(
+            &self.index,
+            self.predictions.get_phase_raw()?,
+        ))
     }
 
-
-    pub fn get_x(&self) -> Result<BlockedDataset2D<f32, Bases>>
-    {
+    pub fn get_x(&self) -> Result<BlockedDataset2D<f32, Bases>> {
         Ok(BlockedDataset2D::new(&self.index, self.genome.get_x_raw()?))
     }
 
     /*
-    /data/err_samples        	Dataset {268164/Inf}			Sida: Mostly TRUE, occasional FALSE
-    /data/fully_intergenic_samples Dataset {268164/Inf}			Sida: Mostly FALSE, occasional TRUE
-    /data/gene_lengths       	Dataset {268164/Inf, 20000}		Longest spanning gene model
-    /data/is_annotated       	Dataset {268164/Inf}			Sida: All TRUE
-    /data/sample_weights     	Dataset {268164/Inf, 20000}
-    /data/seqids             	Dataset {268164/Inf}
-    /data/species            	Dataset {268164/Inf}
-    /data/start_ends         	Dataset {268164/Inf, 2}
-*/
+        /data/err_samples        	Dataset {268164/Inf}			Sida: Mostly TRUE, occasional FALSE
+        /data/fully_intergenic_samples Dataset {268164/Inf}			Sida: Mostly FALSE, occasional TRUE
+        /data/gene_lengths       	Dataset {268164/Inf, 20000}		Longest spanning gene model
+        /data/is_annotated       	Dataset {268164/Inf}			Sida: All TRUE
+        /data/sample_weights     	Dataset {268164/Inf, 20000}
+        /data/seqids             	Dataset {268164/Inf}
+        /data/species            	Dataset {268164/Inf}
+        /data/start_ends         	Dataset {268164/Inf, 2}
+    */
 
-    pub fn get_err_samples(&self) -> Result<Vec<bool>> { self.genome.get_err_samples() }
-
-    pub fn get_fully_intergenic_samples(&self) -> Result<Vec<bool>> { self.genome.get_fully_intergenic_samples() }
-
-    pub fn get_gene_lengths(&self) -> Result<BlockedDataset1D<u32>>
-    {
-        Ok(BlockedDataset1D::new(&self.index, self.genome.get_gene_lengths_raw()?))
+    pub fn get_err_samples(&self) -> Result<Vec<bool>> {
+        self.genome.get_err_samples()
     }
 
-    pub fn get_is_annotated(&self) -> Result<Vec<bool>> { self.genome.get_is_annotated() }
-
-    pub fn get_sample_weights(&self) -> Result<BlockedDataset1D<i8>>
-    {
-        Ok(BlockedDataset1D::new(&self.index, self.genome.get_sample_weights_raw()?))
+    pub fn get_fully_intergenic_samples(&self) -> Result<Vec<bool>> {
+        self.genome.get_fully_intergenic_samples()
     }
 
-    pub fn get_transitions(&self) -> Result<BlockedDataset2D<i8, Transitions>>
-    {
-        Ok(BlockedDataset2D::new(&self.index, self.genome.get_transitions_raw()?))
+    pub fn get_gene_lengths(&self) -> Result<BlockedDataset1D<u32>> {
+        Ok(BlockedDataset1D::new(
+            &self.index,
+            self.genome.get_gene_lengths_raw()?,
+        ))
     }
 
-    pub fn get_class_reference(&self) -> Result<Option<BlockedDataset2D<i8, ClassReference>>>
-    {
-        match self.genome.get_y_raw()?
-        {
+    pub fn get_is_annotated(&self) -> Result<Vec<bool>> {
+        self.genome.get_is_annotated()
+    }
+
+    pub fn get_sample_weights(&self) -> Result<BlockedDataset1D<i8>> {
+        Ok(BlockedDataset1D::new(
+            &self.index,
+            self.genome.get_sample_weights_raw()?,
+        ))
+    }
+
+    pub fn get_transitions(&self) -> Result<BlockedDataset2D<i8, Transitions>> {
+        Ok(BlockedDataset2D::new(
+            &self.index,
+            self.genome.get_transitions_raw()?,
+        ))
+    }
+
+    pub fn get_class_reference(&self) -> Result<Option<BlockedDataset2D<i8, ClassReference>>> {
+        match self.genome.get_y_raw()? {
             Some(dataset) => Ok(Some(BlockedDataset2D::new(&self.index, dataset))),
-            None => Ok(None)
+            None => Ok(None),
         }
     }
 
-    pub fn get_class_reference_as_pseudo_predictions(&self) -> Result<Option<BlockedDataset2D<i8, ClassPrediction>>>
-    {
-        match self.genome.get_y_raw()?
-        {
+    pub fn get_class_reference_as_pseudo_predictions(
+        &self,
+    ) -> Result<Option<BlockedDataset2D<i8, ClassPrediction>>> {
+        match self.genome.get_y_raw()? {
             Some(dataset) => Ok(Some(BlockedDataset2D::new(&self.index, dataset))),
-            None => Ok(None)
+            None => Ok(None),
         }
     }
 
-    pub fn get_phase_reference(&self) -> Result<Option<BlockedDataset2D<i8, PhaseReference>>>
-    {
-        match self.genome.get_phases_raw()?
-        {
+    pub fn get_phase_reference(&self) -> Result<Option<BlockedDataset2D<i8, PhaseReference>>> {
+        match self.genome.get_phases_raw()? {
             Some(dataset) => Ok(Some(BlockedDataset2D::new(&self.index, dataset))),
-            None => Ok(None)
+            None => Ok(None),
         }
     }
 
-    pub fn get_phase_reference_as_pseudo_predictions(&self) -> Result<Option<BlockedDataset2D<i8, PhasePrediction>>>
-    {
-        match self.genome.get_phases_raw()?
-        {
+    pub fn get_phase_reference_as_pseudo_predictions(
+        &self,
+    ) -> Result<Option<BlockedDataset2D<i8, PhasePrediction>>> {
+        match self.genome.get_phases_raw()? {
             Some(dataset) => Ok(Some(BlockedDataset2D::new(&self.index, dataset))),
-            None => Ok(None)
+            None => Ok(None),
         }
     }
-
-
 }
-
-
-
-
 
 // Newtype for Species ID
 
 #[derive(Copy, Clone)]
 pub struct SpeciesID(usize);
 
-impl SpeciesID
-{
-    fn new(id: usize) -> SpeciesID { SpeciesID(id) }
+impl SpeciesID {
+    fn new(id: usize) -> SpeciesID {
+        SpeciesID(id)
+    }
 
-    pub fn inner(&self) -> usize { self.0 }
+    pub fn inner(&self) -> usize {
+        self.0
+    }
 }
 
-pub struct Species
-{
+pub struct Species {
     name: String,
-    id: SpeciesID
+    id: SpeciesID,
 }
 
+impl Species {
+    fn new(name: String, id: SpeciesID) -> Species {
+        Species { name, id }
+    }
 
-impl Species
-{
-    fn new(name: String, id: SpeciesID) -> Species { Species { name, id } }
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
 
-    pub fn get_name(&self) -> &str { &self.name }
-
-    pub fn get_id(&self) -> SpeciesID { self.id }
+    pub fn get_id(&self) -> SpeciesID {
+        self.id
+    }
 }
-
 
 // Newtype for Sequence ID
 
 #[derive(Copy, Clone)]
 pub struct SequenceID(usize);
 
-impl SequenceID
-{
-    fn new(id: usize) -> SequenceID { SequenceID(id) }
+impl SequenceID {
+    fn new(id: usize) -> SequenceID {
+        SequenceID(id)
+    }
 
-    pub fn inner(&self) -> usize { self.0 }
+    pub fn inner(&self) -> usize {
+        self.0
+    }
 }
 
-
-pub struct Sequence
-{
+pub struct Sequence {
     name: String,
     length: u64,
     id: SequenceID,
-    species_id: SpeciesID
+    species_id: SpeciesID,
 }
 
-impl Sequence
-{
-    fn new(name: String, id: SequenceID, species_id: SpeciesID) -> Sequence { Sequence { name, length: 0, id, species_id } }
+impl Sequence {
+    fn new(name: String, id: SequenceID, species_id: SpeciesID) -> Sequence {
+        Sequence {
+            name,
+            length: 0,
+            id,
+            species_id,
+        }
+    }
 
-    fn set_length(&mut self, length: u64) { self.length=length; }
+    fn set_length(&mut self, length: u64) {
+        self.length = length;
+    }
 
-    pub fn get_name(&self) -> &str { &self.name }
+    pub fn get_name(&self) -> &str {
+        &self.name
+    }
 
-    pub fn get_length(&self) -> u64 { self.length }
+    pub fn get_length(&self) -> u64 {
+        self.length
+    }
 
-    pub fn get_id(&self) -> SequenceID { self.id }
+    pub fn get_id(&self) -> SequenceID {
+        self.id
+    }
 
-    pub fn get_species_id(&self) -> SpeciesID { self.species_id }
+    pub fn get_species_id(&self) -> SpeciesID {
+        self.species_id
+    }
 }
-
 
 // Newtype for Block ID
 
 #[derive(Copy, Clone)]
 pub struct BlockID(usize);
 
-impl BlockID
-{
-    fn new(id: usize) -> BlockID { BlockID(id) }
+impl BlockID {
+    fn new(id: usize) -> BlockID {
+        BlockID(id)
+    }
 
-    pub fn inner(&self) -> usize { self.0 }
+    pub fn inner(&self) -> usize {
+        self.0
+    }
 }
-
-

--- a/helixer_post_bin/src/results/conv.rs
+++ b/helixer_post_bin/src/results/conv.rs
@@ -1,52 +1,60 @@
-use ndarray::ArrayView1;
 use hdf5::H5Type;
+use ndarray::ArrayView1;
 
-pub trait ArrayConvFrom<T: Sized + H5Type>
-{
+pub trait ArrayConvFrom<T: Sized + H5Type> {
     fn from(array: ArrayView1<'_, T>) -> Self;
 }
 
-pub trait ArrayConvInto<T>: Sized + H5Type
-{
+pub trait ArrayConvInto<T>: Sized + H5Type {
     fn into(array: ArrayView1<'_, Self>) -> T;
 }
 
-impl<T: Sized + H5Type,U> ArrayConvInto<U> for T where U: ArrayConvFrom<T>
+impl<T: Sized + H5Type, U> ArrayConvInto<U> for T
+where
+    U: ArrayConvFrom<T>,
 {
-    fn into(array: ArrayView1<'_, Self>) -> U { U::from(array) }
+    fn into(array: ArrayView1<'_, Self>) -> U {
+        U::from(array)
+    }
 }
-
 
 #[derive(Clone, Copy)]
-pub struct ClassPrediction
-{
-    values: [f32; 4] // Ordering is intergenic, utr, coding, intron
+pub struct ClassPrediction {
+    values: [f32; 4], // Ordering is intergenic, utr, coding, intron
 }
 
-impl ClassPrediction
-{
-    pub fn get(&self) -> &[f32;4] { &self.values }
+impl ClassPrediction {
+    pub fn get(&self) -> &[f32; 4] {
+        &self.values
+    }
 
-    pub fn get_intergenic(&self) -> f32 { self.values[0] }
+    pub fn get_intergenic(&self) -> f32 {
+        self.values[0]
+    }
 
-    pub fn get_utr(&self) -> f32 { self.values[1] }
+    pub fn get_utr(&self) -> f32 {
+        self.values[1]
+    }
 
-    pub fn get_coding(&self) -> f32 { self.values[2] }
+    pub fn get_coding(&self) -> f32 {
+        self.values[2]
+    }
 
-    pub fn get_intron(&self) -> f32 { self.values[3] }
+    pub fn get_intron(&self) -> f32 {
+        self.values[3]
+    }
 
-    pub fn get_genic(&self) -> f32 { 1.0 - self.values[0] }
+    pub fn get_genic(&self) -> f32 {
+        1.0 - self.values[0]
+    }
 
-    pub fn get_max_idx(&self) -> usize
-    {
-        let mut max=self.values[0];
+    pub fn get_max_idx(&self) -> usize {
+        let mut max = self.values[0];
         let mut max_idx = 0;
 
-        for i in 1..4
-        {
-            if self.values[i] > max
-            {
-                max = self.values [i];
+        for i in 1..4 {
+            if self.values[i] > max {
+                max = self.values[i];
                 max_idx = i;
             }
         }
@@ -55,51 +63,58 @@ impl ClassPrediction
     }
 }
 
-impl ArrayConvFrom<f32> for ClassPrediction
-{
+impl ArrayConvFrom<f32> for ClassPrediction {
     fn from(array: ArrayView1<'_, f32>) -> Self {
-        let values: [f32;4] = [ array[0], array[1], array[2], array[3] ];
+        let values: [f32; 4] = [array[0], array[1], array[2], array[3]];
         ClassPrediction { values }
     }
 }
 
-impl ArrayConvFrom<i8> for ClassPrediction
-{
+impl ArrayConvFrom<i8> for ClassPrediction {
     fn from(array: ArrayView1<'_, i8>) -> Self {
-        let values: [f32;4] = [ array[0] as f32, array[1] as f32, array[2] as f32, array[3] as f32 ];
+        let values: [f32; 4] = [
+            array[0] as f32,
+            array[1] as f32,
+            array[2] as f32,
+            array[3] as f32,
+        ];
         ClassPrediction { values }
     }
 }
-
 
 #[derive(Clone, Copy)]
-pub struct PhasePrediction
-{
-    values: [f32; 4] // Ordering is non_coding, phase 0, phase 1, phase 2
+pub struct PhasePrediction {
+    values: [f32; 4], // Ordering is non_coding, phase 0, phase 1, phase 2
 }
 
-impl PhasePrediction
-{
-    pub fn get(&self) -> &[f32;4] { &self.values }
+impl PhasePrediction {
+    pub fn get(&self) -> &[f32; 4] {
+        &self.values
+    }
 
-    pub fn get_non_coding(&self) -> f32 { self.values[0] }
+    pub fn get_non_coding(&self) -> f32 {
+        self.values[0]
+    }
 
-    pub fn get_phase0(&self) -> f32 { self.values[1] }
+    pub fn get_phase0(&self) -> f32 {
+        self.values[1]
+    }
 
-    pub fn get_phase1(&self) -> f32 { self.values[2] }
+    pub fn get_phase1(&self) -> f32 {
+        self.values[2]
+    }
 
-    pub fn get_phase2(&self) -> f32 { self.values[3] }
+    pub fn get_phase2(&self) -> f32 {
+        self.values[3]
+    }
 
-    pub fn get_max_idx(&self) -> usize
-    {
-        let mut max=self.values[0];
+    pub fn get_max_idx(&self) -> usize {
+        let mut max = self.values[0];
         let mut max_idx = 0;
 
-        for i in 1..4
-        {
-            if self.values[i] > max
-            {
-                max = self.values [i];
+        for i in 1..4 {
+            if self.values[i] > max {
+                max = self.values[i];
                 max_idx = i;
             }
         }
@@ -108,81 +123,77 @@ impl PhasePrediction
     }
 }
 
-impl ArrayConvFrom<f32> for PhasePrediction
-{
+impl ArrayConvFrom<f32> for PhasePrediction {
     fn from(array: ArrayView1<'_, f32>) -> Self {
-        let values: [f32;4] = [ array[0], array[1], array[2], array[3] ];
+        let values: [f32; 4] = [array[0], array[1], array[2], array[3]];
         PhasePrediction { values }
     }
 }
 
-impl ArrayConvFrom<i8> for PhasePrediction
-{
+impl ArrayConvFrom<i8> for PhasePrediction {
     fn from(array: ArrayView1<'_, i8>) -> Self {
-        let values: [f32;4] = [ array[0] as f32, array[1] as f32, array[2] as f32, array[3] as f32 ];
+        let values: [f32; 4] = [
+            array[0] as f32,
+            array[1] as f32,
+            array[2] as f32,
+            array[3] as f32,
+        ];
         PhasePrediction { values }
     }
 }
-
 
 #[derive(Clone, Copy)]
-pub struct Bases
-{
-    values: [f32; 4] // Ordering is C, A, T, G
+pub struct Bases {
+    values: [f32; 4], // Ordering is C, A, T, G
 }
 
-impl Bases
-{
-    pub fn get(&self) -> &[f32; 4] { &self.values }
+impl Bases {
+    pub fn get(&self) -> &[f32; 4] {
+        &self.values
+    }
 }
 
-impl ArrayConvFrom<f32> for Bases
-{
+impl ArrayConvFrom<f32> for Bases {
     fn from(array: ArrayView1<'_, f32>) -> Self {
-        let values: [f32;4] = [ array[0], array[1], array[2], array[3] ];
+        let values: [f32; 4] = [array[0], array[1], array[2], array[3]];
         Bases { values }
     }
 }
 
-pub struct Transitions
-{
-    values: [i8; 6] // Ordering is +TR, +CDS, +In, -TR, -CDS, -In
-                    // [transcription start site, start codon, donor splice site, transcription stop site, stop codon, acceptor splice site]
+pub struct Transitions {
+    values: [i8; 6], // Ordering is +TR, +CDS, +In, -TR, -CDS, -In
+                     // [transcription start site, start codon, donor splice site, transcription stop site, stop codon, acceptor splice site]
 }
 
-impl Transitions
-{
-    pub fn get(&self) -> &[i8; 6] { &self.values }
+impl Transitions {
+    pub fn get(&self) -> &[i8; 6] {
+        &self.values
+    }
 }
 
-impl ArrayConvFrom<i8> for Transitions
-{
+impl ArrayConvFrom<i8> for Transitions {
     fn from(array: ArrayView1<'_, i8>) -> Self {
-        let values: [i8;6] = [ array[0], array[1], array[2], array[3], array[4], array[5] ];
+        let values: [i8; 6] = [array[0], array[1], array[2], array[3], array[4], array[5]];
         Transitions { values }
     }
 }
 
-
-pub struct PhaseReference
-{
-    values: [i8; 4] // Ordering is Non-Coding, Phase 0, Phase 1, Phase2
+pub struct PhaseReference {
+    values: [i8; 4], // Ordering is Non-Coding, Phase 0, Phase 1, Phase2
 }
 
-impl PhaseReference
-{
-    pub fn get(&self) -> &[i8; 4] { &self.values }
+impl PhaseReference {
+    pub fn get(&self) -> &[i8; 4] {
+        &self.values
+    }
 
-    pub fn get_max_idx(&self) -> usize
-    {
-        let mut max=self.values[0];
+    pub fn get_max_idx(&self) -> usize {
+        let mut max = self.values[0];
         let mut max_idx = 0;
 
-        for i in 1..4
-        {
-            if self.values[i] > max
-            {
-                max = self.values [i];
+        for i in 1..4 {
+            if self.values[i] > max {
+                max = self.values[i];
                 max_idx = i;
             }
         }
@@ -191,64 +202,54 @@ impl PhaseReference
     }
 }
 
-impl Default for PhaseReference
-{
-    fn default() -> Self
-    {
-        let values: [i8;4] = [ i8::MAX, 0, 0, 0 ];
+impl Default for PhaseReference {
+    fn default() -> Self {
+        let values: [i8; 4] = [i8::MAX, 0, 0, 0];
         PhaseReference { values }
     }
 }
 
-impl ArrayConvFrom<i8> for PhaseReference
-{
+impl ArrayConvFrom<i8> for PhaseReference {
     fn from(array: ArrayView1<'_, i8>) -> Self {
-        let values: [i8;4] = [ array[0], array[1], array[2], array[3] ];
+        let values: [i8; 4] = [array[0], array[1], array[2], array[3]];
         PhaseReference { values }
     }
 }
-
-
 
 pub struct ClassReference {
-    values: [i8; 4] // Ordering is intergenic, utr, coding, intron
+    values: [i8; 4], // Ordering is intergenic, utr, coding, intron
 }
 
-impl ClassReference
-{
-    pub fn get(&self) -> &[i8; 4] { &self.values }
+impl ClassReference {
+    pub fn get(&self) -> &[i8; 4] {
+        &self.values
+    }
 
-    pub fn get_max_idx(&self) -> usize
-    {
-        let mut max=self.values[0];
+    pub fn get_max_idx(&self) -> usize {
+        let mut max = self.values[0];
         let mut max_idx = 0;
 
-        for i in 1..4
-            {
-            if self.values[i] > max
-                {
-                max= self.values [i];
+        for i in 1..4 {
+            if self.values[i] > max {
+                max = self.values[i];
                 max_idx = i;
-                }
             }
+        }
 
         max_idx
     }
 }
 
-impl Default for ClassReference
-{
-    fn default() -> Self
-    {
-        let values: [i8;4] = [ i8::MAX, 0, 0, 0 ];
+impl Default for ClassReference {
+    fn default() -> Self {
+        let values: [i8; 4] = [i8::MAX, 0, 0, 0];
         ClassReference { values }
     }
 }
 
-impl ArrayConvFrom<i8> for ClassReference
-{
+impl ArrayConvFrom<i8> for ClassReference {
     fn from(array: ArrayView1<'_, i8>) -> Self {
-        let values: [i8;4] = [ array[0], array[1], array[2], array[3] ];
+        let values: [i8; 4] = [array[0], array[1], array[2], array[3]];
         ClassReference { values }
     }
 }

--- a/helixer_post_bin/src/results/error.rs
+++ b/helixer_post_bin/src/results/error.rs
@@ -1,10 +1,6 @@
-
 use std::fmt::{self, Debug, Display};
 
-
-
-pub enum Error
-{
+pub enum Error {
     Hdf5(hdf5::Error),
     MismatchedDimensions(usize, usize),
     MismatchedBlockCount(usize, usize),
@@ -16,13 +12,28 @@ pub enum Error
 
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self
-        {
+        match self {
             Error::Hdf5(err) => Display::fmt(err, f),
-            Error::MismatchedDimensions(found, expected) => write!(f, "Mismatched Dimensions Found {}, expected {}", found, expected),
-            Error::MismatchedBlockCount(found, expected) => write!(f, "Mismatched Block Count: Found {}, expected {}", found, expected),
-            Error::MismatchedBlockSize(found, expected) => write!(f, "Mismatched Block Size: Found {}, expected {}", found, expected),
-            Error::MismatchedDataSize(found, expected) => write!(f, "Mismatched Data Size: Found {}, expected {}", found, expected),
+            Error::MismatchedDimensions(found, expected) => write!(
+                f,
+                "Mismatched Dimensions Found {}, expected {}",
+                found, expected
+            ),
+            Error::MismatchedBlockCount(found, expected) => write!(
+                f,
+                "Mismatched Block Count: Found {}, expected {}",
+                found, expected
+            ),
+            Error::MismatchedBlockSize(found, expected) => write!(
+                f,
+                "Mismatched Block Size: Found {}, expected {}",
+                found, expected
+            ),
+            Error::MismatchedDataSize(found, expected) => write!(
+                f,
+                "Mismatched Data Size: Found {}, expected {}",
+                found, expected
+            ),
             Error::InvalidValue(msg) => write!(f, "Invalid Value: {}", msg),
             Error::DuplicateValue(msg) => write!(f, "Duplicate Value: {}", msg),
         }
@@ -31,30 +42,44 @@ impl Display for Error {
 
 impl Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self
-        {
+        match self {
             Error::Hdf5(err) => Display::fmt(err, f),
-            Error::MismatchedDimensions(found, expected) => write!(f, "Mismatched Dimensions Found {}, expected {}", found, expected),
-            Error::MismatchedBlockCount(found, expected) => write!(f, "Mismatched Block Count: Found {}, expected {}", found, expected),
-            Error::MismatchedBlockSize(found, expected) => write!(f, "Mismatched Block Size: Found {}, expected {}", found, expected),
-            Error::MismatchedDataSize(found, expected) => write!(f, "Mismatched Data Size: Found {}, expected {}", found, expected),
+            Error::MismatchedDimensions(found, expected) => write!(
+                f,
+                "Mismatched Dimensions Found {}, expected {}",
+                found, expected
+            ),
+            Error::MismatchedBlockCount(found, expected) => write!(
+                f,
+                "Mismatched Block Count: Found {}, expected {}",
+                found, expected
+            ),
+            Error::MismatchedBlockSize(found, expected) => write!(
+                f,
+                "Mismatched Block Size: Found {}, expected {}",
+                found, expected
+            ),
+            Error::MismatchedDataSize(found, expected) => write!(
+                f,
+                "Mismatched Data Size: Found {}, expected {}",
+                found, expected
+            ),
             Error::InvalidValue(msg) => write!(f, "Invalid Value: {}", msg),
             Error::DuplicateValue(msg) => write!(f, "Duplicate Value: {}", msg),
         }
     }
 }
 
-impl From<hdf5::Error> for Error
-{
-    fn from(hdf5_error: hdf5::Error) -> Self { Self::Hdf5(hdf5_error) }
+impl From<hdf5::Error> for Error {
+    fn from(hdf5_error: hdf5::Error) -> Self {
+        Self::Hdf5(hdf5_error)
+    }
 }
 
-impl From<&str> for Error
-{
-    fn from(msg: &str) -> Self { Self::InvalidValue(msg.to_string()) }
+impl From<&str> for Error {
+    fn from(msg: &str) -> Self {
+        Self::InvalidValue(msg.to_string())
+    }
 }
 
-impl Error
-{
-
-}
+impl Error {}

--- a/helixer_post_bin/src/results/index.rs
+++ b/helixer_post_bin/src/results/index.rs
@@ -1,31 +1,25 @@
+use std::collections::{BTreeMap, HashMap};
 use std::fmt::Write;
-use std::collections::{HashMap, BTreeMap};
 
 use super::{Error, Result};
 
 use super::raw::RawHelixerGenome;
-use super::{Species, SpeciesID, SequenceID, Sequence, BlockID};
+use super::{BlockID, Sequence, SequenceID, Species, SpeciesID};
 
-
-
-
-pub struct HelixerIndex
-{
+pub struct HelixerIndex {
     species: Vec<Species>,
     species_name_idx: HashMap<String, SpeciesID>,
 
     sequences: Vec<Sequence>,
     sequence_name_idx: Vec<HashMap<String, SequenceID>>, // Species ID -> Map
-    species_sequences: Vec<Vec<SequenceID>>, // Species ID -> [Sequence_ID]
+    species_sequences: Vec<Vec<SequenceID>>,             // Species ID -> [Sequence_ID]
 
     block_offsets: Vec<(u64, u64)>, // Block Idx -> Position range
     sequence_blocks: Vec<(Vec<BlockID>, Vec<BlockID>)>, // SequenceID -> ([BlockID], [BlockID])
 }
 
-impl HelixerIndex
-{
-    pub fn new(genome: &RawHelixerGenome) -> Result<HelixerIndex>
-    {
+impl HelixerIndex {
+    pub fn new(genome: &RawHelixerGenome) -> Result<HelixerIndex> {
         let all_species = genome.get_species()?;
         let all_sequences = genome.get_seqids()?;
         let all_startends = genome.get_start_ends()?;
@@ -33,8 +27,11 @@ impl HelixerIndex
         Self::build_from_slices(&all_species, &all_sequences, &all_startends)
     }
 
-    fn build_from_slices(all_species: &[String], all_sequences: &[String], all_startends: &[(u64,u64)]) -> Result<HelixerIndex>
-    {
+    fn build_from_slices(
+        all_species: &[String],
+        all_sequences: &[String],
+        all_startends: &[(u64, u64)],
+    ) -> Result<HelixerIndex> {
         let mut species = Vec::new();
         let mut species_name_idx = HashMap::new();
 
@@ -43,7 +40,7 @@ impl HelixerIndex
         let mut species_sequences = Vec::new();
 
         let mut block_offsets = Vec::with_capacity(all_startends.len());
-        let mut sequence_blocks_trees= Vec::new(); // Build initially as BTreeMaps
+        let mut sequence_blocks_trees = Vec::new(); // Build initially as BTreeMaps
 
         let mut maybe_last_species_name = None;
         let mut maybe_last_sequence_name = None;
@@ -51,9 +48,13 @@ impl HelixerIndex
         let mut species_id = SpeciesID::new(usize::max_value());
         let mut sequence_id = SequenceID::new(usize::max_value());
 
-        for ((species_name, sequence_name), (start, end)) in all_species.iter().zip(all_sequences.iter()).zip(all_startends.iter())
+        for ((species_name, sequence_name), (start, end)) in all_species
+            .iter()
+            .zip(all_sequences.iter())
+            .zip(all_startends.iter())
         {
-            if maybe_last_species_name.is_none() || maybe_last_species_name.unwrap() != species_name     // New species
+            if maybe_last_species_name.is_none() || maybe_last_species_name.unwrap() != species_name
+            // New species
             {
                 species_id = SpeciesID::new(species.len());
                 species.push(Species::new(species_name.clone(), species_id));
@@ -66,10 +67,16 @@ impl HelixerIndex
                 maybe_last_sequence_name = None;
             }
 
-            if maybe_last_sequence_name.is_none() || maybe_last_sequence_name.unwrap() != sequence_name     // New sequence (or species)
+            if maybe_last_sequence_name.is_none()
+                || maybe_last_sequence_name.unwrap() != sequence_name
+            // New sequence (or species)
             {
                 sequence_id = SequenceID::new(sequences.len());
-                sequences.push(Sequence::new(sequence_name.clone(), sequence_id, species_id));
+                sequences.push(Sequence::new(
+                    sequence_name.clone(),
+                    sequence_id,
+                    species_id,
+                ));
 
                 sequence_name_idx[species_id.0].insert(sequence_name.clone(), sequence_id);
 
@@ -82,179 +89,249 @@ impl HelixerIndex
             let block_id = BlockID::new(block_offsets.len());
             block_offsets.push((*start, *end));
 
-            if start < end
-            {
-                if let Some(prev_id) = sequence_blocks_trees[sequence_id.0].0.insert(*start, block_id)
+            if start < end {
+                if let Some(prev_id) = sequence_blocks_trees[sequence_id.0]
+                    .0
+                    .insert(*start, block_id)
                 {
                     let mut msg = String::new();
-                    write!(&mut msg, "Block Start {} at index {} already occurred at index {}", start, block_id.0, prev_id.0).unwrap();
+                    write!(
+                        &mut msg,
+                        "Block Start {} at index {} already occurred at index {}",
+                        start, block_id.0, prev_id.0
+                    )
+                    .unwrap();
                     return Err(Error::DuplicateValue(msg));
                 }
-            }
-            else if start > end
-            {
-                if let Some(prev_id)  = sequence_blocks_trees[sequence_id.0].1.insert(*end, block_id)
+            } else if start > end {
+                if let Some(prev_id) = sequence_blocks_trees[sequence_id.0]
+                    .1
+                    .insert(*end, block_id)
                 {
                     let mut msg = String::new();
-                    write!(&mut msg, "Block End {} at index {} already occurred at index {}", end, block_id.0, prev_id.0).unwrap();
+                    write!(
+                        &mut msg,
+                        "Block End {} at index {} already occurred at index {}",
+                        end, block_id.0, prev_id.0
+                    )
+                    .unwrap();
                     return Err(Error::DuplicateValue(msg));
                 }
-
+            } else {
+                return Err("Zero length block".into());
             }
-            else
-            { return Err("Zero length block".into()); }
-
         }
 
-        let (sequence_blocks, sequence_lengths)= Self::build_sequence_blocks(sequence_blocks_trees, &block_offsets)?;
+        let (sequence_blocks, sequence_lengths) =
+            Self::build_sequence_blocks(sequence_blocks_trees, &block_offsets)?;
 
-        for (idx, sequence_length) in sequence_lengths.into_iter().enumerate()
-            { sequences[idx].set_length(sequence_length); }
+        for (idx, sequence_length) in sequence_lengths.into_iter().enumerate() {
+            sequences[idx].set_length(sequence_length);
+        }
 
-        Ok( HelixerIndex {species, species_name_idx, sequences, sequence_name_idx, species_sequences, block_offsets, sequence_blocks} )
+        Ok(HelixerIndex {
+            species,
+            species_name_idx,
+            sequences,
+            sequence_name_idx,
+            species_sequences,
+            block_offsets,
+            sequence_blocks,
+        })
     }
 
-    fn build_sequence_blocks_fwd(sequence_block_tree: BTreeMap<u64,BlockID>) -> Result<Vec<BlockID>>
-    {
-        Ok(sequence_block_tree.into_iter().map(|(_k,v)| v).collect())
+    fn build_sequence_blocks_fwd(
+        sequence_block_tree: BTreeMap<u64, BlockID>,
+    ) -> Result<Vec<BlockID>> {
+        Ok(sequence_block_tree.into_iter().map(|(_k, v)| v).collect())
     }
 
-    fn build_sequence_blocks_rev(sequence_block_tree: BTreeMap<u64,BlockID>) -> Result<Vec<BlockID>>
-    {
-        Ok(sequence_block_tree.into_iter().rev().map(|(_k,v)| v).collect())
+    fn build_sequence_blocks_rev(
+        sequence_block_tree: BTreeMap<u64, BlockID>,
+    ) -> Result<Vec<BlockID>> {
+        Ok(sequence_block_tree
+            .into_iter()
+            .rev()
+            .map(|(_k, v)| v)
+            .collect())
     }
 
-    fn check_sequence_block_contiguity(block_indexes: &[BlockID], block_offsets: &[(u64, u64)]) -> Result<(u64, u64)>
-    {
+    fn check_sequence_block_contiguity(
+        block_indexes: &[BlockID],
+        block_offsets: &[(u64, u64)],
+    ) -> Result<(u64, u64)> {
         let mut maybe_prev = None;
-        for (id, curr) in block_indexes.iter().map(|id| ( id, block_offsets[id.0] ))
-        {
-            if let Some(prev) = maybe_prev
-            {
-                if curr.0!=prev
-                {
+        for (id, curr) in block_indexes.iter().map(|id| (id, block_offsets[id.0])) {
+            if let Some(prev) = maybe_prev {
+                if curr.0 != prev {
                     let mut msg = String::new();
-                    write!(&mut msg, "Gap between blocks {} to {} at index {}", prev, curr.0, id.0).unwrap();
+                    write!(
+                        &mut msg,
+                        "Gap between blocks {} to {} at index {}",
+                        prev, curr.0, id.0
+                    )
+                    .unwrap();
                     return Err(Error::InvalidValue(msg));
                 }
                 maybe_prev = Some(curr.1);
             }
         }
 
-        if block_indexes.len()==0
-        { Ok((0,0)) }
-        else
-        { Ok((block_offsets[block_indexes.first().unwrap().0].0, block_offsets[block_indexes.last().unwrap().0].1)) }
+        if block_indexes.len() == 0 {
+            Ok((0, 0))
+        } else {
+            Ok((
+                block_offsets[block_indexes.first().unwrap().0].0,
+                block_offsets[block_indexes.last().unwrap().0].1,
+            ))
+        }
     }
 
-    fn build_sequence_blocks(sequence_block_trees: Vec<(BTreeMap<u64, BlockID>, BTreeMap<u64, BlockID>)>, block_offsets: &[(u64, u64)]) -> Result<(Vec<(Vec<BlockID>, Vec<BlockID>)>, Vec<u64>)>
-    {
-        let sequence_blocks_with_lengths = sequence_block_trees.into_iter().map(
-            |(fwd_tree, rev_tree)|
-                {
-                    let fwd_vec = Self::build_sequence_blocks_fwd(fwd_tree)?;
-                    let rev_vec = Self::build_sequence_blocks_rev(rev_tree)?;
+    fn build_sequence_blocks(
+        sequence_block_trees: Vec<(BTreeMap<u64, BlockID>, BTreeMap<u64, BlockID>)>,
+        block_offsets: &[(u64, u64)],
+    ) -> Result<(Vec<(Vec<BlockID>, Vec<BlockID>)>, Vec<u64>)> {
+        let sequence_blocks_with_lengths = sequence_block_trees
+            .into_iter()
+            .map(|(fwd_tree, rev_tree)| {
+                let fwd_vec = Self::build_sequence_blocks_fwd(fwd_tree)?;
+                let rev_vec = Self::build_sequence_blocks_rev(rev_tree)?;
 
-                    if fwd_vec.len() != rev_vec.len()
-                    { return Err("Forward / Reverse block count mismatched (perhaps using filtered data?)".into()); }
-
-                    let (fwd_start, fwd_end) = Self::check_sequence_block_contiguity(&fwd_vec, block_offsets)?;
-                    let (rev_start, rev_end) = Self::check_sequence_block_contiguity(&rev_vec, block_offsets)?;
-
-                    if fwd_start != 0
-                    { return Err("Forward blocks not starting at offset zero (perhaps using filtered data?)".into()); }
-
-                    if rev_end != 0
-                    { return Err("Reverse blocks not ending at offset zero (perhaps using filtered data?)".into()); }
-
-                    if fwd_end != rev_start
-                    { return Err("Forward / Reverse max offset mismatched (perhaps using filtered data?)".into()); }
-
-                    Ok((fwd_vec, rev_vec, fwd_end))
+                if fwd_vec.len() != rev_vec.len() {
+                    return Err(
+                        "Forward / Reverse block count mismatched (perhaps using filtered data?)"
+                            .into(),
+                    );
                 }
-        ).collect::<Result<Vec<(Vec<BlockID>, Vec<BlockID>, u64)>>>()?;
+
+                let (fwd_start, fwd_end) =
+                    Self::check_sequence_block_contiguity(&fwd_vec, block_offsets)?;
+                let (rev_start, rev_end) =
+                    Self::check_sequence_block_contiguity(&rev_vec, block_offsets)?;
+
+                if fwd_start != 0 {
+                    return Err(
+                        "Forward blocks not starting at offset zero (perhaps using filtered data?)"
+                            .into(),
+                    );
+                }
+
+                if rev_end != 0 {
+                    return Err(
+                        "Reverse blocks not ending at offset zero (perhaps using filtered data?)"
+                            .into(),
+                    );
+                }
+
+                if fwd_end != rev_start {
+                    return Err(
+                        "Forward / Reverse max offset mismatched (perhaps using filtered data?)"
+                            .into(),
+                    );
+                }
+
+                Ok((fwd_vec, rev_vec, fwd_end))
+            })
+            .collect::<Result<Vec<(Vec<BlockID>, Vec<BlockID>, u64)>>>()?;
 
         let mut sequence_blocks = Vec::with_capacity(sequence_blocks_with_lengths.len());
         let mut sequence_lengths = Vec::with_capacity(sequence_blocks_with_lengths.len());
 
-        for (fwd_blocks, rev_blocks, length) in sequence_blocks_with_lengths.into_iter()
-            {
+        for (fwd_blocks, rev_blocks, length) in sequence_blocks_with_lengths.into_iter() {
             sequence_blocks.push((fwd_blocks, rev_blocks));
             sequence_lengths.push(length);
-            }
+        }
 
         Ok((sequence_blocks, sequence_lengths))
     }
 
-    pub fn get_all_species(&self) -> &[Species] { &self.species }
-
-    pub fn get_species_by_id (&self, id: SpeciesID) -> &Species { &self.species[id.0] }
-
-    pub fn get_species_by_name (&self, name: &str) -> Option<&Species>
-    {
-        self.species_name_idx.get(name).and_then(|id| self.species.get(id.0))
+    pub fn get_all_species(&self) -> &[Species] {
+        &self.species
     }
 
-    pub fn get_all_sequences(&self) -> &[Sequence] { &self.sequences }
-
-    pub fn get_sequence_by_id(&self, id: SequenceID) -> &Sequence { &self.sequences[id.0] }
-
-    pub fn get_sequence_by_species_id_and_sequence_name(&self, species_id: SpeciesID, sequence_name: &str) -> Option<&Sequence>
-    {
-        self.sequence_name_idx[species_id.0].get(sequence_name).and_then(|id| self.sequences.get(id.0))
+    pub fn get_species_by_id(&self, id: SpeciesID) -> &Species {
+        &self.species[id.0]
     }
 
-    pub fn get_sequences_for_all_species(&self) -> &[Vec<SequenceID>] { &self.species_sequences }
+    pub fn get_species_by_name(&self, name: &str) -> Option<&Species> {
+        self.species_name_idx
+            .get(name)
+            .and_then(|id| self.species.get(id.0))
+    }
 
-    pub fn get_sequences_for_species(&self, id: SpeciesID) -> &[SequenceID] { &self.species_sequences[id.0] }
+    pub fn get_all_sequences(&self) -> &[Sequence] {
+        &self.sequences
+    }
 
-    pub fn get_all_block_offsets(&self) -> &[(u64, u64)] { &self.block_offsets }
+    pub fn get_sequence_by_id(&self, id: SequenceID) -> &Sequence {
+        &self.sequences[id.0]
+    }
 
-    pub fn get_all_block_ids(&self) -> &[(Vec<BlockID>, Vec<BlockID>)] { & self.sequence_blocks }
+    pub fn get_sequence_by_species_id_and_sequence_name(
+        &self,
+        species_id: SpeciesID,
+        sequence_name: &str,
+    ) -> Option<&Sequence> {
+        self.sequence_name_idx[species_id.0]
+            .get(sequence_name)
+            .and_then(|id| self.sequences.get(id.0))
+    }
 
-    pub fn get_block_ids_for_sequence(&self, id: SequenceID) -> &(Vec<BlockID>, Vec<BlockID>) { &self.sequence_blocks[id.0] }
+    pub fn get_sequences_for_all_species(&self) -> &[Vec<SequenceID>] {
+        &self.species_sequences
+    }
 
+    pub fn get_sequences_for_species(&self, id: SpeciesID) -> &[SequenceID] {
+        &self.species_sequences[id.0]
+    }
 
+    pub fn get_all_block_offsets(&self) -> &[(u64, u64)] {
+        &self.block_offsets
+    }
 
+    pub fn get_all_block_ids(&self) -> &[(Vec<BlockID>, Vec<BlockID>)] {
+        &self.sequence_blocks
+    }
 
+    pub fn get_block_ids_for_sequence(&self, id: SequenceID) -> &(Vec<BlockID>, Vec<BlockID>) {
+        &self.sequence_blocks[id.0]
+    }
 
-    pub fn dump(&self)
-    {
+    pub fn dump(&self) {
         println!("Species Count: {}", self.species.len());
 
-        for (species_idx, species) in self.species.iter().enumerate()
-        {
+        for (species_idx, species) in self.species.iter().enumerate() {
             println!("Species [{}] is {}", species_idx, species.get_name());
 
             let sequence_idxs = &self.species_sequences[species_idx];
             println!("    Sequence Count: {}", sequence_idxs.len());
 
-            for (sequence_idx, sequence) in sequence_idxs.iter().map(|idx| (idx, &self.sequences[idx.0]))
+            for (sequence_idx, sequence) in sequence_idxs
+                .iter()
+                .map(|idx| (idx, &self.sequences[idx.0]))
             {
-                println!("    Sequence [{}] is {}", sequence_idx.0, sequence.get_name());
+                println!(
+                    "    Sequence [{}] is {}",
+                    sequence_idx.0,
+                    sequence.get_name()
+                );
 
                 let (fwd_blocks, rev_blocks) = &self.sequence_blocks[sequence_idx.0];
                 print!("        Fwd Block Count: {} -", fwd_blocks.len());
 
-                for block in fwd_blocks.iter()
-                {
+                for block in fwd_blocks.iter() {
                     let (block_start, block_end) = self.block_offsets[block.0];
                     print!(" {}({}:{})", block.0, block_start, block_end);
                 }
                 println!();
 
                 print!("        Rev Block Count: {} -", rev_blocks.len());
-                for block in rev_blocks.iter()
-                {
+                for block in rev_blocks.iter() {
                     let (block_start, block_end) = self.block_offsets[block.0];
                     print!(" {}({}:{})", block.0, block_start, block_end);
                 }
                 println!();
             }
-
         }
     }
-
-
 }
-

--- a/helixer_post_bin/src/results/iter.rs
+++ b/helixer_post_bin/src/results/iter.rs
@@ -1,232 +1,241 @@
-
 use super::BlockID;
 use hdf5::{Dataset, H5Type};
 
-use ndarray::{Array1, Array2, s, Axis, ArrayView1};
+use ndarray::{s, Array1, Array2, ArrayView1, Axis};
 
 use super::HelixerIndex;
+use crate::results::conv::ArrayConvInto;
 use crate::results::SequenceID;
 use std::marker::PhantomData;
 use std::ops::Range;
-use crate::results::conv::ArrayConvInto;
-
 
 // Should be possible to merge the 1D / 2D versions at some stage with a non-trivial amount of generic magic
 
-
-pub struct BlockedDataset1D<'a, T: H5Type + Clone + Copy>
-{
+pub struct BlockedDataset1D<'a, T: H5Type + Clone + Copy> {
     index: &'a HelixerIndex,
     dataset: Dataset,
-    phantom: PhantomData<T>
+    phantom: PhantomData<T>,
 }
 
-impl<'a, T: H5Type + Clone + Copy> BlockedDataset1D<'a, T>
-{
-    pub fn new(index: &'a HelixerIndex, dataset: Dataset) -> BlockedDataset1D<'a, T>
-    {
-        BlockedDataset1D { index, dataset, phantom: PhantomData }
+impl<'a, T: H5Type + Clone + Copy> BlockedDataset1D<'a, T> {
+    pub fn new(index: &'a HelixerIndex, dataset: Dataset) -> BlockedDataset1D<'a, T> {
+        BlockedDataset1D {
+            index,
+            dataset,
+            phantom: PhantomData,
+        }
     }
 
-    pub fn get_index(&self) -> &HelixerIndex { self.index }
+    pub fn get_index(&self) -> &HelixerIndex {
+        self.index
+    }
 
-    pub fn get_dataset(&self) -> &Dataset { &self.dataset }
+    pub fn get_dataset(&self) -> &Dataset {
+        &self.dataset
+    }
 
-    pub fn fwd_iter(&'a self, id: SequenceID) -> BlockedDataset1DIter<'a, T>
-    {
+    pub fn fwd_iter(&'a self, id: SequenceID) -> BlockedDataset1DIter<'a, T> {
         let (fwd, _rev) = self.index.get_block_ids_for_sequence(id);
         let block_offsets = self.index.get_all_block_offsets();
 
         BlockedDataset1DIter::new(&self, block_offsets, fwd)
     }
 
-    pub fn rev_iter(&'a self, id: SequenceID) -> BlockedDataset1DIter<'a, T>
-    {
+    pub fn rev_iter(&'a self, id: SequenceID) -> BlockedDataset1DIter<'a, T> {
         let (_fwd, rev) = self.index.get_block_ids_for_sequence(id);
         let block_offsets = self.index.get_all_block_offsets();
 
         BlockedDataset1DIter::new(&self, block_offsets, rev)
     }
 
-    fn get_data_for_block(&self, block_id: BlockID) -> hdf5::Result<Array1<T>>
-    {
-        let slice = s![block_id.inner(), .. ];
+    fn get_data_for_block(&self, block_id: BlockID) -> hdf5::Result<Array1<T>> {
+        let slice = s![block_id.inner(), ..];
         self.dataset.read_slice_1d::<T, _>(&slice)
     }
 }
 
-
-
-pub struct BlockedDataset1DIter<'a, T: H5Type + Clone + Copy>
-{
+pub struct BlockedDataset1DIter<'a, T: H5Type + Clone + Copy> {
     blocked_dataset: &'a BlockedDataset1D<'a, T>,
     block_offsets: &'a [(u64, u64)],
     block_iter: std::slice::Iter<'a, BlockID>,
 
     block: Option<(BlockID, Array1<T>, Range<usize>)>,
-
 }
 
-impl<'a, T: H5Type + Clone + Copy> BlockedDataset1DIter<'a, T>
-{
-    fn new(blocked_dataset: &'a BlockedDataset1D<'a, T>, block_offsets: &'a [(u64, u64)], blocks: &'a[BlockID]) -> BlockedDataset1DIter<'a, T>
-    {
+impl<'a, T: H5Type + Clone + Copy> BlockedDataset1DIter<'a, T> {
+    fn new(
+        blocked_dataset: &'a BlockedDataset1D<'a, T>,
+        block_offsets: &'a [(u64, u64)],
+        blocks: &'a [BlockID],
+    ) -> BlockedDataset1DIter<'a, T> {
         let block_iter = blocks.iter();
-        let mut iter = BlockedDataset1DIter { blocked_dataset, block_offsets, block_iter, block: None };
+        let mut iter = BlockedDataset1DIter {
+            blocked_dataset,
+            block_offsets,
+            block_iter,
+            block: None,
+        };
         iter.block = iter.next_block();
         iter
     }
 
-    fn next_block(&mut self) -> Option<(BlockID, Array1<T>, Range<usize>)>
-    {
-        self.block_iter.next()
-            .map(|id| {
-                let data = self.blocked_dataset.get_data_for_block(*id).expect("Failed to read block");
-                let (start, end) = self.block_offsets[id.inner()];
-                let length = if start < end { end - start } else { start - end } as usize;
+    fn next_block(&mut self) -> Option<(BlockID, Array1<T>, Range<usize>)> {
+        self.block_iter.next().map(|id| {
+            let data = self
+                .blocked_dataset
+                .get_data_for_block(*id)
+                .expect("Failed to read block");
+            let (start, end) = self.block_offsets[id.inner()];
+            let length = if start < end {
+                end - start
+            } else {
+                start - end
+            } as usize;
 
-                (*id, data, 0..length) }
-            )
+            (*id, data, 0..length)
+        })
     }
 
-    fn next_position(&mut self) -> (bool, Option<usize>)
-    {
-        if let Some((_, _, ref mut block_range)) = self.block
-        { (true, block_range.next()) }
-        else
-        { (false, None) }
-
+    fn next_position(&mut self) -> (bool, Option<usize>) {
+        if let Some((_, _, ref mut block_range)) = self.block {
+            (true, block_range.next())
+        } else {
+            (false, None)
+        }
     }
 }
 
-impl<'a, T: H5Type + Clone + Copy> Iterator for BlockedDataset1DIter<'a, T>
-{
+impl<'a, T: H5Type + Clone + Copy> Iterator for BlockedDataset1DIter<'a, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (_, maybe_offset) =
-            match self.next_position()
-            {
-                (true, None) => { self.block = self.next_block(); self.next_position() },
-                keep => keep
-            };
+        let (_, maybe_offset) = match self.next_position() {
+            (true, None) => {
+                self.block = self.next_block();
+                self.next_position()
+            }
+            keep => keep,
+        };
 
-        if let (Some(offset), Some((_, block_array, _))) = (maybe_offset, self.block.as_ref())
-        {
+        if let (Some(offset), Some((_, block_array, _))) = (maybe_offset, self.block.as_ref()) {
             Some(block_array[offset])
+        } else {
+            None
         }
-        else
-        { None }
     }
 }
 
-
-
-
-pub struct BlockedDataset2D<'a, T: ArrayConvInto<O>, O>
-{
+pub struct BlockedDataset2D<'a, T: ArrayConvInto<O>, O> {
     index: &'a HelixerIndex,
     dataset: Dataset,
-    phantom: PhantomData<(T,O)>
+    phantom: PhantomData<(T, O)>,
 }
 
-impl<'a, T: ArrayConvInto<O>, O> BlockedDataset2D<'a, T, O>
-{
-    pub fn new(index: &'a HelixerIndex, dataset: Dataset) -> BlockedDataset2D<'a, T, O>
-    {
-        BlockedDataset2D { index, dataset, phantom: PhantomData }
+impl<'a, T: ArrayConvInto<O>, O> BlockedDataset2D<'a, T, O> {
+    pub fn new(index: &'a HelixerIndex, dataset: Dataset) -> BlockedDataset2D<'a, T, O> {
+        BlockedDataset2D {
+            index,
+            dataset,
+            phantom: PhantomData,
+        }
     }
 
-    pub fn get_index(&self) -> &HelixerIndex { self.index }
+    pub fn get_index(&self) -> &HelixerIndex {
+        self.index
+    }
 
-    pub fn get_dataset(&self) -> &Dataset { &self.dataset }
+    pub fn get_dataset(&self) -> &Dataset {
+        &self.dataset
+    }
 
-    pub fn fwd_iter(&'a self, id: SequenceID) -> BlockedDataset2DIter<'a, T, O>
-    {
+    pub fn fwd_iter(&'a self, id: SequenceID) -> BlockedDataset2DIter<'a, T, O> {
         let (fwd, _rev) = self.index.get_block_ids_for_sequence(id);
         let block_offsets = self.index.get_all_block_offsets();
 
         BlockedDataset2DIter::new(&self, block_offsets, fwd)
     }
 
-    pub fn rev_iter(&'a self, id: SequenceID) -> BlockedDataset2DIter<'a, T, O>
-    {
+    pub fn rev_iter(&'a self, id: SequenceID) -> BlockedDataset2DIter<'a, T, O> {
         let (_fwd, rev) = self.index.get_block_ids_for_sequence(id);
         let block_offsets = self.index.get_all_block_offsets();
 
-        BlockedDataset2DIter::new(&self, block_offsets,rev)
+        BlockedDataset2DIter::new(&self, block_offsets, rev)
     }
 
-    fn get_data_for_block(&self, block_id: BlockID) -> hdf5::Result<Array2<T>>
-    {
-        let slice = s![block_id.inner(), .. , .. ];
+    fn get_data_for_block(&self, block_id: BlockID) -> hdf5::Result<Array2<T>> {
+        let slice = s![block_id.inner(), .., ..];
         self.dataset.read_slice_2d::<T, _>(&slice)
     }
-
 }
 
-
-
-pub struct BlockedDataset2DIter<'a, T: ArrayConvInto<O>, O>
-{
+pub struct BlockedDataset2DIter<'a, T: ArrayConvInto<O>, O> {
     blocked_dataset: &'a BlockedDataset2D<'a, T, O>,
     block_offsets: &'a [(u64, u64)],
     block_iter: std::slice::Iter<'a, BlockID>,
 
     block: Option<(BlockID, Array2<T>, Range<usize>)>,
-
 }
 
-impl<'a, T: ArrayConvInto<O>, O> BlockedDataset2DIter<'a, T, O>
-{
-    fn new(blocked_dataset: &'a BlockedDataset2D<'a, T, O>, block_offsets: &'a [(u64, u64)], blocks: &'a[BlockID]) -> BlockedDataset2DIter<'a, T, O>
-    {
+impl<'a, T: ArrayConvInto<O>, O> BlockedDataset2DIter<'a, T, O> {
+    fn new(
+        blocked_dataset: &'a BlockedDataset2D<'a, T, O>,
+        block_offsets: &'a [(u64, u64)],
+        blocks: &'a [BlockID],
+    ) -> BlockedDataset2DIter<'a, T, O> {
         let block_iter = blocks.iter();
-        let mut iter = BlockedDataset2DIter { blocked_dataset, block_offsets, block_iter, block: None };
+        let mut iter = BlockedDataset2DIter {
+            blocked_dataset,
+            block_offsets,
+            block_iter,
+            block: None,
+        };
         iter.block = iter.next_block();
         iter
     }
 
-    fn next_block(&mut self) -> Option<(BlockID, Array2<T>, Range<usize>)>
-    {
-        self.block_iter.next()
-            .map(|id| {
-                let data = self.blocked_dataset.get_data_for_block(*id).expect("Failed to read block");
-                let (start, end) = self.block_offsets[id.inner()];
-                let length = if start < end { end - start } else { start - end } as usize;
+    fn next_block(&mut self) -> Option<(BlockID, Array2<T>, Range<usize>)> {
+        self.block_iter.next().map(|id| {
+            let data = self
+                .blocked_dataset
+                .get_data_for_block(*id)
+                .expect("Failed to read block");
+            let (start, end) = self.block_offsets[id.inner()];
+            let length = if start < end {
+                end - start
+            } else {
+                start - end
+            } as usize;
 
-                (*id, data, 0..length) }
-            )
+            (*id, data, 0..length)
+        })
     }
 
-    fn next_position(&mut self) -> (bool, Option<usize>)
-    {
-        if let Some((_, _, ref mut block_range)) = self.block
-            { (true, block_range.next()) }
-        else
-            { (false, None) }
-
+    fn next_position(&mut self) -> (bool, Option<usize>) {
+        if let Some((_, _, ref mut block_range)) = self.block {
+            (true, block_range.next())
+        } else {
+            (false, None)
+        }
     }
 }
 
-impl<'a, T: ArrayConvInto<O>, O> Iterator for BlockedDataset2DIter<'a, T, O>
-{
+impl<'a, T: ArrayConvInto<O>, O> Iterator for BlockedDataset2DIter<'a, T, O> {
     type Item = O;
 
     fn next(&mut self) -> Option<Self::Item> {
-        let (_, maybe_offset) =
-            match self.next_position()
-                {
-                    (true, None) => { self.block = self.next_block(); self.next_position() },
-                    keep => keep
-                };
-
-        if let (Some(offset), Some((_, block_array, _))) = (maybe_offset, self.block.as_ref())
-            {
-            let slice: ArrayView1<T> = block_array.index_axis(Axis(0), offset);//.to_owned();
-            Some(T::into(slice))
+        let (_, maybe_offset) = match self.next_position() {
+            (true, None) => {
+                self.block = self.next_block();
+                self.next_position()
             }
-        else
-            { None }
+            keep => keep,
+        };
+
+        if let (Some(offset), Some((_, block_array, _))) = (maybe_offset, self.block.as_ref()) {
+            let slice: ArrayView1<T> = block_array.index_axis(Axis(0), offset); //.to_owned();
+            Some(T::into(slice))
+        } else {
+            None
+        }
     }
 }

--- a/helixer_post_bin/src/results/raw.rs
+++ b/helixer_post_bin/src/results/raw.rs
@@ -1,6 +1,5 @@
 mod genome;
 mod predictions;
 
-
 pub use genome::RawHelixerGenome;
 pub use predictions::RawHelixerPredictions;

--- a/helixer_post_bin/src/results/raw/genome.rs
+++ b/helixer_post_bin/src/results/raw/genome.rs
@@ -1,17 +1,15 @@
-
 use super::super::{Error, Result};
-use hdf5::{File, Dataset};
-use std::path::Path;
 use hdf5::types::FixedAscii;
+use hdf5::{Dataset, File};
+use std::path::Path;
 
 //use ndarray::iter::Iter;
 
-pub struct RawHelixerGenome
-{
+pub struct RawHelixerGenome {
     genome_file: File,
 
     blocks: usize,
-    blocksize: usize
+    blocksize: usize,
 }
 
 const X_DATASIZE: usize = 4;
@@ -33,219 +31,223 @@ pub enum ErrSamples
 type SeqidsType = FixedAscii<[u8; 50]>;
 type SpeciesType = FixedAscii<[u8; 25]>;
 
-impl RawHelixerGenome
-{
-    pub fn new(genome_file_path: &Path, blocks: usize, blocksize: usize) -> Result<RawHelixerGenome>
-    {
+impl RawHelixerGenome {
+    pub fn new(
+        genome_file_path: &Path,
+        blocks: usize,
+        blocksize: usize,
+    ) -> Result<RawHelixerGenome> {
         let genome_file = File::open(genome_file_path)?;
-        Ok(RawHelixerGenome { genome_file, blocks, blocksize })
+        Ok(RawHelixerGenome {
+            genome_file,
+            blocks,
+            blocksize,
+        })
     }
 
     // Should be 1D - [Blocks]
-    fn validate_dataset_shape_scalar(&self, dataset: &Dataset) -> Result<()>
-    {
+    fn validate_dataset_shape_scalar(&self, dataset: &Dataset) -> Result<()> {
         let shape = dataset.shape();
-        if shape.len()!=1
-            { return Err(Error::MismatchedDimensions(shape.len(), 1)); }
+        if shape.len() != 1 {
+            return Err(Error::MismatchedDimensions(shape.len(), 1));
+        }
 
-        if shape[0]!= self.blocks
-            { return Err(Error::MismatchedBlockCount(shape[0], self.blocks)); }
+        if shape[0] != self.blocks {
+            return Err(Error::MismatchedBlockCount(shape[0], self.blocks));
+        }
 
         Ok(())
     }
 
     // Should be 2D - [Blocks][size]
-    fn validate_dataset_shape_array(&self, dataset: &Dataset, data_size: usize) -> Result<()>
-    {
+    fn validate_dataset_shape_array(&self, dataset: &Dataset, data_size: usize) -> Result<()> {
         let shape = dataset.shape();
-        if shape.len()!=2
-            { return Err(Error::MismatchedDimensions(shape.len(), 2)); }
+        if shape.len() != 2 {
+            return Err(Error::MismatchedDimensions(shape.len(), 2));
+        }
 
-        if shape[0]!= self.blocks
-            { return Err(Error::MismatchedBlockCount(shape[0], self.blocks)); }
+        if shape[0] != self.blocks {
+            return Err(Error::MismatchedBlockCount(shape[0], self.blocks));
+        }
 
-        if shape[1]!= data_size
-            { return Err(Error::MismatchedDataSize(shape[2], data_size)); }
+        if shape[1] != data_size {
+            return Err(Error::MismatchedDataSize(shape[2], data_size));
+        }
 
         Ok(())
     }
 
     // Should be 2D - [Blocks][Blocksize]
-    fn validate_dataset_shape_blocksize_scalar(&self, dataset: &Dataset) -> Result<()>
-    {
+    fn validate_dataset_shape_blocksize_scalar(&self, dataset: &Dataset) -> Result<()> {
         let shape = dataset.shape();
-        if shape.len()!=2
-            { return Err(Error::MismatchedDimensions(shape.len(), 2)); }
+        if shape.len() != 2 {
+            return Err(Error::MismatchedDimensions(shape.len(), 2));
+        }
 
-        if shape[0]!= self.blocks
-            { return Err(Error::MismatchedBlockCount(shape[0], self.blocks)); }
+        if shape[0] != self.blocks {
+            return Err(Error::MismatchedBlockCount(shape[0], self.blocks));
+        }
 
-        if shape[1]!= self.blocksize
-            { return Err(Error::MismatchedBlockSize(shape[1], self.blocksize)); }
+        if shape[1] != self.blocksize {
+            return Err(Error::MismatchedBlockSize(shape[1], self.blocksize));
+        }
 
         Ok(())
     }
 
     // Should be 3D - [Blocks][Blocksize][size]
-    fn validate_dataset_shape_blocksize_array(&self, dataset: &Dataset, data_size: usize) -> Result<()>
-    {
+    fn validate_dataset_shape_blocksize_array(
+        &self,
+        dataset: &Dataset,
+        data_size: usize,
+    ) -> Result<()> {
         let shape = dataset.shape();
-        if shape.len()!=3
-            { return Err(Error::MismatchedDimensions(shape.len(), 3)); }
+        if shape.len() != 3 {
+            return Err(Error::MismatchedDimensions(shape.len(), 3));
+        }
 
-        if shape[0]!= self.blocks
-        { return Err(Error::MismatchedBlockCount(shape[0], self.blocks)); }
+        if shape[0] != self.blocks {
+            return Err(Error::MismatchedBlockCount(shape[0], self.blocks));
+        }
 
-        if shape[1]!= self.blocksize
-            { return Err(Error::MismatchedBlockSize(shape[1], self.blocksize)); }
+        if shape[1] != self.blocksize {
+            return Err(Error::MismatchedBlockSize(shape[1], self.blocksize));
+        }
 
-        if shape[2]!= data_size
-            { return Err(Error::MismatchedDataSize(shape[2], data_size)); }
+        if shape[2] != data_size {
+            return Err(Error::MismatchedDataSize(shape[2], data_size));
+        }
 
         Ok(())
     }
 
-    pub fn get_x_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_x_raw(&self) -> Result<Dataset> {
         let dataset = self.genome_file.dataset("data/X")?;
         self.validate_dataset_shape_blocksize_array(&dataset, X_DATASIZE)?;
         Ok(dataset)
     }
 
-    pub fn get_err_samples_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_err_samples_raw(&self) -> Result<Dataset> {
         let dataset = self.genome_file.dataset("data/err_samples")?;
         self.validate_dataset_shape_scalar(&dataset)?;
         Ok(dataset)
     }
 
-    pub fn get_err_samples(&self) -> Result<Vec<bool>>
-    {
+    pub fn get_err_samples(&self) -> Result<Vec<bool>> {
         let err_samples_ds = self.get_err_samples_raw()?;
         let err_samples_array = err_samples_ds.read_1d::<bool>()?;
         Ok(err_samples_array.to_vec())
 
-//      let err_samples_array = err_samples_ds.read_1d::<ErrSamples>()?;
-//      Ok(err_samples_array.iter().map(|x| *x == ErrSamples::TRUE).collect())
+        //      let err_samples_array = err_samples_ds.read_1d::<ErrSamples>()?;
+        //      Ok(err_samples_array.iter().map(|x| *x == ErrSamples::TRUE).collect())
     }
 
-    pub fn get_fully_intergenic_samples_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_fully_intergenic_samples_raw(&self) -> Result<Dataset> {
         let dataset = self.genome_file.dataset("data/fully_intergenic_samples")?;
         self.validate_dataset_shape_scalar(&dataset)?;
         Ok(dataset)
     }
 
-    pub fn get_fully_intergenic_samples(&self) -> Result<Vec<bool>>
-    {
+    pub fn get_fully_intergenic_samples(&self) -> Result<Vec<bool>> {
         let fully_ig_samples_ds = self.get_fully_intergenic_samples_raw()?;
         let fully_ig_samples_array = fully_ig_samples_ds.read_1d::<bool>()?;
         Ok(fully_ig_samples_array.to_vec())
     }
 
     // For pre-annotated
-    pub fn get_gene_lengths_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_gene_lengths_raw(&self) -> Result<Dataset> {
         let dataset = self.genome_file.dataset("data/gene_lengths")?;
         self.validate_dataset_shape_blocksize_scalar(&dataset)?;
         Ok(dataset)
     }
 
     // For pre-annotated
-    pub fn get_is_annotated_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_is_annotated_raw(&self) -> Result<Dataset> {
         let dataset = self.genome_file.dataset("data/is_annotated")?;
         self.validate_dataset_shape_scalar(&dataset)?;
         Ok(dataset)
     }
 
-    pub fn get_is_annotated(&self) -> Result<Vec<bool>>
-    {
+    pub fn get_is_annotated(&self) -> Result<Vec<bool>> {
         let is_annotated_ds = self.get_is_annotated_raw()?;
         let is_annotated_array = is_annotated_ds.read_1d::<bool>()?;
         Ok(is_annotated_array.to_vec())
     }
 
     // For pre-annotated
-    pub fn get_phases_raw(&self) -> Result<Option<Dataset>>
-    {
-        if !self.genome_file.link_exists("data/phases") { return Ok(None); }
+    pub fn get_phases_raw(&self) -> Result<Option<Dataset>> {
+        if !self.genome_file.link_exists("data/phases") {
+            return Ok(None);
+        }
 
         let dataset = self.genome_file.dataset("data/phases")?;
         self.validate_dataset_shape_blocksize_array(&dataset, PHASE_DATASIZE)?;
         Ok(Some(dataset))
     }
 
-    pub fn get_sample_weights_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_sample_weights_raw(&self) -> Result<Dataset> {
         let dataset = self.genome_file.dataset("data/sample_weights")?;
         self.validate_dataset_shape_blocksize_scalar(&dataset)?;
         Ok(dataset)
     }
 
-    pub fn get_seqids_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_seqids_raw(&self) -> Result<Dataset> {
         let dataset = self.genome_file.dataset("data/seqids")?;
         self.validate_dataset_shape_scalar(&dataset)?;
         Ok(dataset)
     }
 
-    pub fn get_seqids(&self) -> Result<Vec<String>>
-    {
+    pub fn get_seqids(&self) -> Result<Vec<String>> {
         let seqids_ds = self.get_seqids_raw()?;
         let seqids_array = seqids_ds.read_1d::<SeqidsType>()?;
 
         Ok(seqids_array.iter().map(|x| x.to_string()).collect())
     }
 
-    pub fn get_species_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_species_raw(&self) -> Result<Dataset> {
         let dataset = self.genome_file.dataset("data/species")?;
         self.validate_dataset_shape_scalar(&dataset)?;
         Ok(dataset)
     }
 
-    pub fn get_species(&self) -> Result<Vec<String>>
-    {
+    pub fn get_species(&self) -> Result<Vec<String>> {
         let species_ds = self.get_species_raw()?;
         let species_array = species_ds.read_1d::<SpeciesType>()?;
 
         Ok(species_array.iter().map(|x| x.to_string()).collect())
     }
 
-    pub fn get_start_ends_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_start_ends_raw(&self) -> Result<Dataset> {
         let dataset = self.genome_file.dataset("data/start_ends")?;
         self.validate_dataset_shape_array(&dataset, STARTENDS_DATASIZE)?;
         Ok(dataset)
     }
 
-    pub fn get_start_ends(&self) -> Result<Vec<(u64,u64)>>
-    {
+    pub fn get_start_ends(&self) -> Result<Vec<(u64, u64)>> {
         let startends_ds = self.get_start_ends_raw()?;
         let startends_array = startends_ds.read_2d::<i64>()?;
 
-        Ok(startends_array.outer_iter().map(
-            |x| ( x[0] as u64, x[1] as u64 )
-        ).collect())
+        Ok(startends_array
+            .outer_iter()
+            .map(|x| (x[0] as u64, x[1] as u64))
+            .collect())
     }
 
     // For pre-annotated
-    pub fn get_transitions_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_transitions_raw(&self) -> Result<Dataset> {
         let dataset = self.genome_file.dataset("data/transitions")?;
         self.validate_dataset_shape_blocksize_array(&dataset, TRANSITIONS_DATASIZE)?;
         Ok(dataset)
     }
 
     // For pre-annotated
-    pub fn get_y_raw(&self) -> Result<Option<Dataset>>
-    {
-        if !self.genome_file.link_exists("data/y") { return Ok(None); }
+    pub fn get_y_raw(&self) -> Result<Option<Dataset>> {
+        if !self.genome_file.link_exists("data/y") {
+            return Ok(None);
+        }
 
         let dataset = self.genome_file.dataset("data/y")?;
         self.validate_dataset_shape_blocksize_array(&dataset, Y_DATASIZE)?;
         Ok(Some(dataset))
     }
-
 }

--- a/helixer_post_bin/src/results/raw/predictions.rs
+++ b/helixer_post_bin/src/results/raw/predictions.rs
@@ -1,62 +1,61 @@
-
 use super::super::{Error, Result};
 use hdf5::{Dataset, File};
 use std::path::Path;
 
-pub struct RawHelixerPredictions
-{
-    predictions_file: File
+pub struct RawHelixerPredictions {
+    predictions_file: File,
 }
 
 const CLASS_DATASIZE: usize = 4;
 const PHASE_DATASIZE: usize = 4;
 
-impl RawHelixerPredictions
-{
-    pub fn new(predictions_file_path: &Path) -> Result<RawHelixerPredictions>
-    {
+impl RawHelixerPredictions {
+    pub fn new(predictions_file_path: &Path) -> Result<RawHelixerPredictions> {
         let predictions_file = File::open(predictions_file_path)?;
         Ok(RawHelixerPredictions { predictions_file })
     }
 
-    pub fn get_class_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_class_raw(&self) -> Result<Dataset> {
         let pred_dataset = self.predictions_file.dataset("predictions")?;
 
         let shape = pred_dataset.shape();
-        if shape.len()!=3
-            { return Err(Error::MismatchedDimensions(shape.len(), 3)); }
+        if shape.len() != 3 {
+            return Err(Error::MismatchedDimensions(shape.len(), 3));
+        }
 
-        if shape[2]!= CLASS_DATASIZE
-            { return Err(Error::MismatchedDataSize(shape[2], CLASS_DATASIZE)); }
+        if shape[2] != CLASS_DATASIZE {
+            return Err(Error::MismatchedDataSize(shape[2], CLASS_DATASIZE));
+        }
 
         Ok(pred_dataset)
     }
 
-    pub fn get_phase_raw(&self) -> Result<Dataset>
-    {
+    pub fn get_phase_raw(&self) -> Result<Dataset> {
         let phase_dataset = self.predictions_file.dataset("predictions_phase")?;
 
         let shape = phase_dataset.shape();
-        if shape.len()!=3
-            { return Err(Error::MismatchedDimensions(shape.len(), 3)); }
+        if shape.len() != 3 {
+            return Err(Error::MismatchedDimensions(shape.len(), 3));
+        }
 
         let (blocks, blocksize) = self.get_blocks_and_blocksize()?;
 
-        if shape[0]!= blocks
-            { return Err(Error::MismatchedBlockCount(shape[0], blocks)); }
+        if shape[0] != blocks {
+            return Err(Error::MismatchedBlockCount(shape[0], blocks));
+        }
 
-        if shape[1]!= blocksize
-            { return Err(Error::MismatchedDataSize(shape[1], blocksize)); }
+        if shape[1] != blocksize {
+            return Err(Error::MismatchedDataSize(shape[1], blocksize));
+        }
 
-        if shape[2]!= PHASE_DATASIZE
-            { return Err(Error::MismatchedDataSize(shape[2], PHASE_DATASIZE)); }
+        if shape[2] != PHASE_DATASIZE {
+            return Err(Error::MismatchedDataSize(shape[2], PHASE_DATASIZE));
+        }
 
         Ok(phase_dataset)
     }
 
-    pub fn get_blocks_and_blocksize(&self) -> Result<(usize, usize)>
-    {
+    pub fn get_blocks_and_blocksize(&self) -> Result<(usize, usize)> {
         let pred_dataset = self.get_class_raw()?;
         let shape = pred_dataset.shape();
 
@@ -65,5 +64,4 @@ impl RawHelixerPredictions
 
         Ok((blocks, blocksize))
     }
-
 }


### PR DESCRIPTION
- Writes gff header for gff version and species at the start of the output file 
- Writes header with region name, start and end coordinates for each "region" 
- Checks that there's only one "species" for the gff output 

I couldn't get the hdf5 .attrs["model_md5sum"] out of the hdf5 file, so there's still a TODO...