### PR TITLE
hdf5 dependencies update

### DIFF
--- a/helixer_post_bin/Cargo.toml
+++ b/helixer_post_bin/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Tony Bolger <bolger.tony@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-hdf5 = "0.7.1"
-ndarray = "0.14.0"
+hdf5 = "0.8.1"
+ndarray = "0.15.6"

--- a/helixer_post_bin/src/gff.rs
+++ b/helixer_post_bin/src/gff.rs
@@ -209,7 +209,7 @@ impl<W: Write> GffWriter<W> {
         const GFF_VERSION: &'static str = "3.2.1";
         write!(self.writer, "##gff-version {}\n", GFF_VERSION)?;
         if let Some(species) = species {
-            write!(self.writer, "##{}\n", species)?;
+            write!(self.writer, "##species {}\n", species)?;
         }
         if let Some(helixer_model_md5sum) = helixer_model_md5sum {
             write!(self.writer, "# {}\n", helixer_model_md5sum)?;

--- a/helixer_post_bin/src/gff.rs
+++ b/helixer_post_bin/src/gff.rs
@@ -204,7 +204,7 @@ impl<W: Write> GffWriter<W> {
     pub fn write_global_header(
         &mut self,
         species: Option<&str>,
-        helixer_model_md5sum: Option<&str>,
+        helixer_model_md5sum: Option<String>,
     ) -> std::io::Result<()> {
         const GFF_VERSION: &'static str = "3.2.1";
         write!(self.writer, "##gff-version {}\n", GFF_VERSION)?;

--- a/helixer_post_bin/src/main.rs
+++ b/helixer_post_bin/src/main.rs
@@ -3,9 +3,11 @@ use helixer_post_bin::analysis::hmm::show_hmm_config;
 use helixer_post_bin::analysis::rater::SequenceRating;
 use helixer_post_bin::analysis::Analyzer;
 use helixer_post_bin::gff::GffWriter;
+use helixer_post_bin::results::raw::RawHelixerPredictions;
 use helixer_post_bin::results::HelixerResults;
 use std::fs::File;
 use std::io::BufWriter;
+use std::path::Path;
 use std::process::exit;
 
 fn main() {
@@ -56,8 +58,11 @@ fn main() {
         1,
         "Error: Multiple Species are not allowed for GFF output."
     );
-    let model_md5sum = None; // TODO: this should fetch <hdf5>.attrs['model_md5sum']
+    let rhg = RawHelixerPredictions::new(&Path::new(predictions_path))
+        .expect("Error: Something went wrong while accessing the predictions.");
+    let model_md5sum = rhg.get_model_md5sum().ok();
     let species_name = helixer_res.get_all_species().first().map(|x| x.get_name());
+
     gff_writer
         .write_global_header(species_name, model_md5sum)
         .expect(&*format!(

--- a/helixer_post_bin/src/results/iter.rs
+++ b/helixer_post_bin/src/results/iter.rs
@@ -50,7 +50,7 @@ impl<'a, T: H5Type + Clone + Copy> BlockedDataset1D<'a, T> {
 
     fn get_data_for_block(&self, block_id: BlockID) -> hdf5::Result<Array1<T>> {
         let slice = s![block_id.inner(), ..];
-        self.dataset.read_slice_1d::<T, _>(&slice)
+        self.dataset.read_slice_1d(slice)
     }
 }
 
@@ -164,7 +164,7 @@ impl<'a, T: ArrayConvInto<O>, O> BlockedDataset2D<'a, T, O> {
 
     fn get_data_for_block(&self, block_id: BlockID) -> hdf5::Result<Array2<T>> {
         let slice = s![block_id.inner(), .., ..];
-        self.dataset.read_slice_2d::<T, _>(&slice)
+        self.dataset.read_slice_2d(slice)
     }
 }
 

--- a/helixer_post_bin/src/results/raw/genome.rs
+++ b/helixer_post_bin/src/results/raw/genome.rs
@@ -28,8 +28,8 @@ pub enum ErrSamples
 }
 */
 
-type SeqidsType = FixedAscii<[u8; 50]>;
-type SpeciesType = FixedAscii<[u8; 25]>;
+type SeqidsType = FixedAscii<50>;
+type SpeciesType = FixedAscii<25>;
 
 impl RawHelixerGenome {
     pub fn new(

--- a/helixer_post_bin/src/results/raw/predictions.rs
+++ b/helixer_post_bin/src/results/raw/predictions.rs
@@ -1,5 +1,5 @@
 use super::super::{Error, Result};
-use hdf5::{Dataset, File};
+use hdf5::{types::*, Dataset, File};
 use std::path::Path;
 
 pub struct RawHelixerPredictions {
@@ -13,6 +13,12 @@ impl RawHelixerPredictions {
     pub fn new(predictions_file_path: &Path) -> Result<RawHelixerPredictions> {
         let predictions_file = File::open(predictions_file_path)?;
         Ok(RawHelixerPredictions { predictions_file })
+    }
+
+    pub fn get_model_md5sum(&self) -> Result<String> {
+        let attr = self.predictions_file.attr("model_md5sum")?;
+        let r: VarLenUnicode = attr.as_reader().read_scalar()?;
+        Ok(r.to_string())
     }
 
     pub fn get_class_raw(&self) -> Result<Dataset> {

--- a/helixer_post_bin/src/results/raw/predictions.rs
+++ b/helixer_post_bin/src/results/raw/predictions.rs
@@ -1,5 +1,5 @@
 use super::super::{Error, Result};
-use hdf5::{types::*, Dataset, File};
+use hdf5::{types::VarLenUnicode, Dataset, File};
 use std::path::Path;
 
 pub struct RawHelixerPredictions {


### PR DESCRIPTION
In order to get to the attributes for the missing line in the gff output header, the hdf5 dependency needed to be updated (and therefore also ndarray). The gff3 header now contains the md5sum line from Helixer.

Updated dependencies:

    hdf5 = "0.8.1"
    ndarray = "0.15.6"

New "features":

    add get_model_md5sum() to RawHelixerPrediction

Bugfix (for #2):

    add forgotten "##species " to header line 

